### PR TITLE
fix: make MessageHeaders public

### DIFF
--- a/src/KafkaFlow/MessageHeaders.cs
+++ b/src/KafkaFlow/MessageHeaders.cs
@@ -4,24 +4,43 @@ namespace KafkaFlow
     using System.Collections.Generic;
     using Confluent.Kafka;
 
-    internal class MessageHeaders : IMessageHeaders
+    /// <summary>
+    /// Collection of message headers
+    /// </summary>
+    public class MessageHeaders : IMessageHeaders
     {
         private readonly Headers headers;
 
+        /// <summary>
+        /// Creates a <see cref="MessageHeaders"/> instance
+        /// </summary>
+        /// <param name="headers"></param>
         public MessageHeaders(Headers headers)
         {
             this.headers = headers;
         }
 
+        /// <summary>
+        /// Creates a <see cref="MessageHeaders"/> instance
+        /// </summary>
         public MessageHeaders() : this(new Headers())
         {
         }
 
+        /// <summary>
+        /// Adds a new header to the enumeration
+        /// </summary>
+        /// <param name="key">The header key.</param>
+        /// <param name="value">The header value (possibly null)</param>
         public void Add(string key, byte[] value)
         {
             this.headers.Add(key, value);
         }
 
+        /// <summary>
+        /// Gets the header with specified key
+        /// </summary>
+        /// <param name="key">The zero-based index of the element to get</param>
         public byte[] this[string key]
         {
             get => this.headers.TryGetLastBytes(key, out var value) ? value : null;
@@ -32,8 +51,17 @@ namespace KafkaFlow
             }
         }
 
+        /// <summary>
+        /// Gets all the kafka headers
+        /// </summary>
+        /// <returns></returns>
         public Headers GetKafkaHeaders() => this.headers;
 
+        
+        /// <summary>
+        /// Gets an enumerator that iterates through <see cref="Headers"/>
+        /// </summary>
+        /// <returns></returns>
         public IEnumerator<KeyValuePair<string, byte[]>> GetEnumerator()
         {
             foreach (var header in this.headers)


### PR DESCRIPTION
# Description

Class MessageHeaders now is public.

Fixes #34 

## How Has This Been Tested?

Unit and integration tests were executed

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
