### PR TITLE
fix: bug in OffsetManager with offset gaps

### DIFF
--- a/samples/KafkaFlow.Sample/Program.cs
+++ b/samples/KafkaFlow.Sample/Program.cs
@@ -47,7 +47,7 @@
                                     .WithGroupId("print-console-handler")
                                     .WithName(consumerName)
                                     .WithBufferSize(100)
-                                    .WithWorkersCount(1)
+                                    .WithWorkersCount(20)
                                     .WithAutoOffsetReset(AutoOffsetReset.Latest)
                                     .AddMiddlewares(
                                         middlewares => middlewares

--- a/src/KafkaFlow.UnitTests/OffsetManagerTests.cs
+++ b/src/KafkaFlow.UnitTests/OffsetManagerTests.cs
@@ -27,20 +27,10 @@ namespace KafkaFlow.UnitTests
         }
         
         [TestMethod]
-        public void StoreOffset_WithoutInitialization_ThrowsException()
-        {
-            // Act
-            Action act = () => this.target.StoreOffset(new TopicPartitionOffset(this.topicPartition, new Offset(1) ));
-            
-            // Assert
-            act.Should().Throw<InvalidOperationException>();
-        }
-        
-        [TestMethod]
         public void StoreOffset_WithInvalidTopicPartition_ShouldDoNothing()
         {
             // Arrange
-            this.target.InitializeOffsetIfNeeded(new TopicPartitionOffset(this.topicPartition, new Offset(1)));
+            this.target.AddOffset(new TopicPartitionOffset(this.topicPartition, new Offset(1)));
             
             // Act
             this.target.StoreOffset(new TopicPartitionOffset(new TopicPartition("topic-B", new Partition(1)), new Offset(1)));
@@ -53,7 +43,9 @@ namespace KafkaFlow.UnitTests
         public void StoreOffset_WithGaps_ShouldStoreOffsetJustOnce()
         {
             // Arrange
-            this.target.InitializeOffsetIfNeeded(new TopicPartitionOffset(this.topicPartition, new Offset(1)));
+            this.target.AddOffset(new TopicPartitionOffset(this.topicPartition, new Offset(1)));
+            this.target.AddOffset(new TopicPartitionOffset(this.topicPartition, new Offset(2)));
+            this.target.AddOffset(new TopicPartitionOffset(this.topicPartition, new Offset(3)));
             
             // Act
             this.target.StoreOffset(new TopicPartitionOffset(this.topicPartition, new Offset(3)));

--- a/src/KafkaFlow/Consumers/OffsetManager.cs
+++ b/src/KafkaFlow/Consumers/OffsetManager.cs
@@ -39,13 +39,13 @@ namespace KafkaFlow.Consumers
             }
         }
 
-        public void InitializeOffsetIfNeeded(TopicPartitionOffset partitionOffset)
+        public void AddOffset(TopicPartitionOffset offset)
         {
-            if (
-                this.partitionsOffsets.TryGetValue((partitionOffset.Topic, partitionOffset.Partition.Value), out var offsets) &&
-                offsets.LastOffset == Offset.Unset)
+            if (this.partitionsOffsets.TryGetValue(
+                (offset.Topic, offset.Partition.Value),
+                out var offsets))
             {
-                offsets.InitializeLastOffset(partitionOffset.Offset.Value - 1);
+                offsets.AddOffset(offset.Offset.Value);
             }
         }
 


### PR DESCRIPTION
# Description

Fix a bug in OffsetManager when we have topic/partition with offset gaps

## How Has This Been Tested?

We changed the unit tests to cover these cases and create a new one to simulate a concurrent scenario

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
