### PR TITLE
fix: adds WorkerCount property to MessageConsumer

### DIFF
--- a/src/KafkaFlow/Consumers/MessageConsumer.cs
+++ b/src/KafkaFlow/Consumers/MessageConsumer.cs
@@ -33,6 +33,8 @@ namespace KafkaFlow.Consumers
 
         public string GroupId => this.configuration.GroupId;
 
+        public int WorkerCount => this.configuration.WorkerCount;
+
         public async Task OverrideOffsetsAndRestartAsync(IReadOnlyCollection<TopicPartitionOffset> offsets)
         {
             if (offsets is null)


### PR DESCRIPTION
# Description

Using the KafkaFlow.Admin.WebApi it's possible to change the WorkerCount of a specific consumer.

Currently, there is no way to know how many workers are set to the consumer.

## How Has This Been Tested?

1. GET to API consumer endpoint (https://localhost:5001/kafka-flow/groups/TestGroup/consumers/TestConsumer)

## Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
