### PR TITLE
Log Kafka errors according to severity

### DIFF
--- a/src/KafkaFlow/Consumers/KafkaConsumer.cs
+++ b/src/KafkaFlow/Consumers/KafkaConsumer.cs
@@ -41,7 +41,17 @@
             this.consumerBuilder
                 .SetPartitionsAssignedHandler((consumer, partitions) => this.OnPartitionAssigned(consumer, partitions))
                 .SetPartitionsRevokedHandler((consumer, partitions) => this.OnPartitionRevoked(partitions))
-                .SetErrorHandler((p, error) => this.logHandler.Error("Kafka Consumer Error", null, new { Error = error }));
+                .SetErrorHandler((p, error) =>
+                {
+                    if (error.IsFatal)
+                    {
+                        this.logHandler.Error("Kafka Consumer Fatal Error", null, new { Error = error });
+                    }
+                    else
+                    {
+                        this.logHandler.Warning("Kafka Consumer Error", new { Error = error });
+                    }
+                });
         }
 
         private void OnPartitionRevoked(IReadOnlyCollection<TopicPartitionOffset> topicPartitions)

--- a/src/KafkaFlow/Producers/MessageProducer.cs
+++ b/src/KafkaFlow/Producers/MessageProducer.cs
@@ -165,10 +165,7 @@ namespace KafkaFlow.Producers
                             {
                                 this.dependencyResolverScope.Resolver
                                     .Resolve<ILogHandler>()
-                                    .Error(
-                                        "Kafka Producer Error",
-                                        new KafkaException(error),
-                                        new { Error = error });
+                                    .Warning("Kafka Producer Error", new { Error = error });
                             }
                         })
                     .Build();


### PR DESCRIPTION
# Description

Currently we are logging all consumer or producer Kafka errors with severity 'Error'. There are non-fatal errors, like when a consumer is disconnected being logged as 'Error'. These are normal and expected "errors" when the consumer times out after no activity for 10 minutes (default).

This PR sets the log severity according to the error being fatal or non-fatal.

Fixes #89

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
