### PR TITLE
feat: allow middlewares to be registered at the beginning

### DIFF
--- a/src/KafkaFlow.Abstractions/Configuration/IConsumerMiddlewareConfigurationBuilder.cs
+++ b/src/KafkaFlow.Abstractions/Configuration/IConsumerMiddlewareConfigurationBuilder.cs
@@ -20,11 +20,30 @@ namespace KafkaFlow.Configuration
             where T : class, IMessageMiddleware;
 
         /// <summary>
+        /// Registers a middleware at the beginning of the middleware list
+        /// The middleware will run before other middlewares that already have been registered
+        /// </summary>
+        /// <param name="factory">A factory to create the instance</param>
+        /// <typeparam name="T">A class that implements the <see cref="IMessageMiddleware"/></typeparam>
+        /// <returns></returns>
+        IConsumerMiddlewareConfigurationBuilder AddAtBeginning<T>(Factory<T> factory)
+            where T : class, IMessageMiddleware;
+
+        /// <summary>
         /// Registers a middleware
         /// </summary>
         /// <typeparam name="T">A class that implements the <see cref="IMessageMiddleware"/></typeparam>
         /// <returns></returns>
         IConsumerMiddlewareConfigurationBuilder Add<T>()
+            where T : class, IMessageMiddleware;
+
+        /// <summary>
+        /// Registers a middleware at the beginning of the middleware list 
+        /// The middleware will run before other middlewares that already have been registered
+        /// </summary>
+        /// <typeparam name="T">A class that implements the <see cref="IMessageMiddleware"/></typeparam>
+        /// <returns></returns>
+        IConsumerMiddlewareConfigurationBuilder AddAtBeginning<T>()
             where T : class, IMessageMiddleware;
     }
 }

--- a/src/KafkaFlow/Configuration/ConsumerMiddlewareConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ConsumerMiddlewareConfigurationBuilder.cs
@@ -21,13 +21,31 @@ namespace KafkaFlow.Configuration
             return this;
         }
 
+        public IConsumerMiddlewareConfigurationBuilder AddAtBeginning<T>(Factory<T> factory) where T : class, IMessageMiddleware
+        {
+            this.middlewaresFactories.Insert(0, factory);
+            return this;
+        }
+
         public IConsumerMiddlewareConfigurationBuilder Add<T>() where T : class, IMessageMiddleware
         {
-            this.DependencyConfigurator.AddTransient<T>();
+            this.RegisterType<T>();
             this.middlewaresFactories.Add(resolver => resolver.Resolve<T>());
             return this;
         }
 
+        public IConsumerMiddlewareConfigurationBuilder AddAtBeginning<T>() where T : class, IMessageMiddleware
+        {
+            this.RegisterType<T>();
+            this.middlewaresFactories.Insert(0, resolver => resolver.Resolve<T>());
+            return this;
+        }        
+
         public MiddlewareConfiguration Build() => new MiddlewareConfiguration(this.middlewaresFactories);
+
+        private void RegisterType<T>() where T : class, IMessageMiddleware
+        {
+            this.DependencyConfigurator.AddTransient<T>();
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR add support for middlewares to be registered to run before other middlewares.

Fixes #94 

## How Has This Been Tested?

Using the sample project and registering a middlewares first, then registering a second middleware using the AddAtBegining() method and make sure the second middleware is called first.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
