### PR TITLE
feat: adds Assembly name and ramdom string to KafkaFlow admin consumer

### DIFF
--- a/src/KafkaFlow.Admin/Extensions/ClusterConfigurationBuilderExtensions.cs
+++ b/src/KafkaFlow.Admin/Extensions/ClusterConfigurationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace KafkaFlow
 {
     using System;
+    using System.Reflection;
     using KafkaFlow.Admin;
     using KafkaFlow.Admin.Handlers;
     using KafkaFlow.Configuration;
@@ -28,7 +29,7 @@
                 .AddConsumer(
                     consumer => consumer
                         .Topic(adminTopic)
-                        .WithGroupId(adminConsumerGroup)
+                        .WithGroupId($"{adminConsumerGroup}-{Environment.MachineName}-{Convert.ToBase64String(Guid.NewGuid().ToByteArray())}")
                         .WithWorkersCount(1)
                         .WithBufferSize(1)
                         .WithAutoOffsetReset(AutoOffsetReset.Latest)
@@ -46,7 +47,7 @@
             this IClusterConfigurationBuilder cluster,
             string adminTopic)
         {
-            return cluster.EnableAdminMessages(adminTopic, $"Admin.{Environment.MachineName}");
+            return cluster.EnableAdminMessages(adminTopic, $"Admin-{Assembly.GetEntryAssembly().GetName().Name}");
         }
     }
 }


### PR DESCRIPTION
# Description

This Pull Request changes the way the application adds the consumer for KafkaFlow.Admin.

If the application needs to scale all machine hosts will have the same consumer group.

Fixes #93 

## How Has This Been Tested?

Running the project `KafkaFlow.Admin.WebApi.Sample`:

- Endpoint: https://localhost:5001/kafka-flow/groups
- Result:
![image](https://user-images.githubusercontent.com/11857291/96009637-cae69a80-0e38-11eb-8e73-1b4f28ae49a2.png)

## Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
