### PR TITLE
feat: access message timestamp from message consumer context

### DIFF
--- a/src/KafkaFlow.Abstractions/IMessageContextConsumer.cs
+++ b/src/KafkaFlow.Abstractions/IMessageContextConsumer.cs
@@ -1,5 +1,6 @@
 namespace KafkaFlow
 {
+    using System;
     using System.Threading;
 
     /// <summary>
@@ -16,6 +17,11 @@ namespace KafkaFlow
         /// A CancellationToken that is cancelled when the worker is requested to stop
         /// </summary>
         CancellationToken WorkerStopped { get; }
+
+        /// <summary>
+        /// Message timestamp. By default is the UTC timestamp when the message was produced
+        /// </summary>
+        DateTime MessageTimestamp { get; }
 
         /// <summary>
         /// Gets or Sets if the framework should store the current offset in the end when auto store offset is used

--- a/src/KafkaFlow.UnitTests/MessageContextConsumerTests.cs
+++ b/src/KafkaFlow.UnitTests/MessageContextConsumerTests.cs
@@ -1,0 +1,36 @@
+﻿namespace KafkaFlow.UnitTests
+{
+    using System;
+    using System.Threading;
+    using Confluent.Kafka;
+    using FluentAssertions;
+    using KafkaFlow.Consumers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class MessageContextConsumerTests
+    {
+        [TestMethod]
+        public void MessageTimestamp_ConsumeResultHasMessageTimestamp_ReturnsMessageTimestampFromResult()
+        {
+            // Arrange
+            var expectedMessageTimestamp = new DateTime(2020, 1, 1, 0, 0, 0);
+
+            var consumerResult = new ConsumeResult<byte[], byte[]>
+            {
+                Message = new Message<byte[], byte[]>
+                {
+                    Timestamp = new Timestamp(expectedMessageTimestamp)
+                }
+            };
+
+            var target = new MessageContextConsumer(null, "consumer", null, consumerResult, CancellationToken.None);
+
+            // Act
+            var messageTimestamp = target.MessageTimestamp;
+
+            // Assert
+            messageTimestamp.Should().Be(expectedMessageTimestamp);
+        }
+    }
+}

--- a/src/KafkaFlow/Consumers/MessageContextConsumer.cs
+++ b/src/KafkaFlow/Consumers/MessageContextConsumer.cs
@@ -1,5 +1,6 @@
 namespace KafkaFlow.Consumers
 {
+    using System;
     using System.Threading;
     using Confluent.Kafka;
 
@@ -13,7 +14,7 @@ namespace KafkaFlow.Consumers
             IConsumer<byte[], byte[]> consumer,
             string name,
             IOffsetManager offsetManager,
-            ConsumeResult<byte[], byte[]> kafkaResult, 
+            ConsumeResult<byte[], byte[]> kafkaResult,
             CancellationToken workerStopped)
         {
             this.Name = name;
@@ -24,10 +25,12 @@ namespace KafkaFlow.Consumers
         }
 
         public string Name { get; }
-        
+
         public CancellationToken WorkerStopped { get; }
 
         public bool ShouldStoreOffset { get; set; } = true;
+
+        public DateTime MessageTimestamp => this.kafkaResult.Message.Timestamp.UtcDateTime;
 
         public void StoreOffset()
         {


### PR DESCRIPTION
# Description

Access to message timestamp can be important for observability (e.g. monitoring) 

This Pull Request enables the access to the message timestamp from the Message Consumer Context.

## How Has This Been Tested?

- Unit test was created to make sure the MessageTimestamp is returned from the Kafka ConsumeResult
- Run the sample and checked that the message being consumed has the correct timestamp reported

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
