### PR TITLE
fix: paused consumers send heartbeats

### DIFF
--- a/src/KafkaFlow.Admin/Handlers/PauseConsumersByGroupTopicHandler.cs
+++ b/src/KafkaFlow.Admin/Handlers/PauseConsumersByGroupTopicHandler.cs
@@ -19,7 +19,9 @@ namespace KafkaFlow.Admin.Handlers
 
             foreach (var consumer in consumers)
             {
-                consumer.Pause(consumer.Assignment.Where(x => x.Topic == message.Topic));
+                consumer.Pause(consumer.Assignment
+                    .Where(x => x.Topic == message.Topic)
+                    .ToList());
             }
 
             return Task.CompletedTask;

--- a/src/KafkaFlow.Admin/Handlers/ResumeConsumersByGroupTopicHandler.cs
+++ b/src/KafkaFlow.Admin/Handlers/ResumeConsumersByGroupTopicHandler.cs
@@ -18,7 +18,9 @@ namespace KafkaFlow.Admin.Handlers
 
             foreach (var consumer in consumers)
             {
-                consumer.Resume(consumer.Assignment.Where(x => x.Topic == message.Topic));
+                consumer.Resume(consumer.Assignment
+                    .Where(x => x.Topic == message.Topic)
+                    .ToList());
             }
 
             return Task.CompletedTask;

--- a/src/KafkaFlow.IntegrationTests/ConsumerTest.cs
+++ b/src/KafkaFlow.IntegrationTests/ConsumerTest.cs
@@ -100,5 +100,27 @@ namespace KafkaFlow.IntegrationTests
 
             CollectionAssert.AreEqual(versionsSent, versionsReceived);
         }
+        
+        [TestMethod]
+        public async Task PauseResumeHeartbeatTest()
+        {
+            // Arrange
+            var producer = this.provider.GetRequiredService<IMessageProducer<ProtobufProducer>>();
+            var messages = this.fixture.CreateMany<TestMessage1>(10).ToList();
+
+            // Act
+            await Task.WhenAll(messages.Select(m => producer.ProduceAsync(
+                Bootstrapper.PauseResumeTopicName,
+                m.Id.ToString(), 
+                m)));
+            
+            await Task.Delay(60000);
+            
+            // Assert
+            foreach (var message in messages)
+            {
+                await MessageStorage.AssertMessageAsync(message);
+            }
+        }
     }
 }

--- a/src/KafkaFlow.IntegrationTests/Core/Handlers/PauseResumeHandler.cs
+++ b/src/KafkaFlow.IntegrationTests/Core/Handlers/PauseResumeHandler.cs
@@ -1,0 +1,20 @@
+namespace KafkaFlow.IntegrationTests.Core.Handlers
+{
+    using System.Threading.Tasks;
+    using KafkaFlow.TypedHandler;
+    using Messages;
+
+    public class PauseResumeHandler : IMessageHandler<TestMessage1>
+    {
+        public async Task Handle(IMessageContext context, TestMessage1 message)
+        {
+            context.Consumer.Pause();
+            
+            await Task.Delay(Bootstrapper.MaxPollIntervalMs + 1000);
+            
+            MessageStorage.Add(message);
+            
+            context.Consumer.Resume();
+        }
+    }
+}

--- a/src/KafkaFlow.UnitTests/MessageContextConsumerTests.cs
+++ b/src/KafkaFlow.UnitTests/MessageContextConsumerTests.cs
@@ -24,7 +24,7 @@
                 }
             };
 
-            var target = new MessageContextConsumer(null, "consumer", null, consumerResult, CancellationToken.None);
+            var target = new MessageContextConsumer(null, null, consumerResult, CancellationToken.None);
 
             // Act
             var messageTimestamp = target.MessageTimestamp;

--- a/src/KafkaFlow/Configuration/KafkaFlowConfigurator.cs
+++ b/src/KafkaFlow/Configuration/KafkaFlowConfigurator.cs
@@ -1,7 +1,6 @@
 namespace KafkaFlow.Configuration
 {
     using System;
-    using System.Linq;
     using KafkaFlow.Consumers;
     using KafkaFlow.Producers;
 

--- a/src/KafkaFlow/Consumers/IKafkaConsumer.cs
+++ b/src/KafkaFlow/Consumers/IKafkaConsumer.cs
@@ -14,6 +14,8 @@ namespace KafkaFlow.Consumers
 
         IReadOnlyList<TopicPartition> Assignment { get; }
 
+        IKafkaConsumerFlowManager FlowManager { get; }
+
         string MemberId { get; }
 
         string ClientInstanceName { get; }
@@ -21,10 +23,6 @@ namespace KafkaFlow.Consumers
         Task StartAsync();
 
         Task StopAsync();
-
-        void Pause(IEnumerable<TopicPartition> topicPartitions);
-
-        void Resume(IEnumerable<TopicPartition> topicPartitions);
 
         Offset GetPosition(TopicPartition topicPartition);
 

--- a/src/KafkaFlow/Consumers/IKafkaConsumer.cs
+++ b/src/KafkaFlow/Consumers/IKafkaConsumer.cs
@@ -4,9 +4,12 @@ namespace KafkaFlow.Consumers
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Confluent.Kafka;
+    using KafkaFlow.Configuration;
 
     internal interface IKafkaConsumer
     {
+        ConsumerConfiguration Configuration { get; }
+
         IReadOnlyList<string> Subscription { get; }
 
         IReadOnlyList<TopicPartition> Assignment { get; }

--- a/src/KafkaFlow/Consumers/IKafkaConsumerFlowManager.cs
+++ b/src/KafkaFlow/Consumers/IKafkaConsumerFlowManager.cs
@@ -1,0 +1,12 @@
+namespace KafkaFlow.Consumers
+{
+    using System.Collections.Generic;
+    using Confluent.Kafka;
+
+    internal interface IKafkaConsumerFlowManager
+    {
+        void Pause(IReadOnlyCollection<TopicPartition> topicPartitions);
+
+        void Resume(IReadOnlyCollection<TopicPartition> topicPartitions);
+    }
+}

--- a/src/KafkaFlow/Consumers/IMessageConsumer.cs
+++ b/src/KafkaFlow/Consumers/IMessageConsumer.cs
@@ -81,7 +81,7 @@ namespace KafkaFlow.Consumers
         /// <exception cref="T:Confluent.Kafka.TopicPartitionException">
         ///     Per partition success or error.
         /// </exception>
-        void Pause(IEnumerable<TopicPartition> partitions);
+        void Pause(IReadOnlyCollection<TopicPartition> partitions);
 
         /// <summary>
         ///     Resume consumption for the provided list of partitions.
@@ -95,7 +95,7 @@ namespace KafkaFlow.Consumers
         /// <exception cref="T:Confluent.Kafka.TopicPartitionException">
         ///     Per partition success or error.
         /// </exception>
-        void Resume(IEnumerable<TopicPartition> partitions);
+        void Resume(IReadOnlyCollection<TopicPartition> partitions);
 
         /// <summary>
         ///     Gets the current position (offset) for the

--- a/src/KafkaFlow/Consumers/KafkaConsumer.cs
+++ b/src/KafkaFlow/Consumers/KafkaConsumer.cs
@@ -10,7 +10,6 @@
 
     internal class KafkaConsumer : IKafkaConsumer
     {
-        private readonly ConsumerConfiguration configuration;
         private readonly IConsumerManager consumerManager;
         private readonly ILogHandler logHandler;
         private readonly IConsumerWorkerPool consumerWorkerPool;
@@ -30,7 +29,7 @@
             IConsumerWorkerPool consumerWorkerPool,
             CancellationToken busStopCancellationToken)
         {
-            this.configuration = configuration;
+            this.Configuration = configuration;
             this.consumerManager = consumerManager;
             this.logHandler = logHandler;
             this.consumerWorkerPool = consumerWorkerPool;
@@ -64,6 +63,8 @@
                         }
                     });
         }
+        
+        public ConsumerConfiguration Configuration { get; }
 
         public IReadOnlyList<string> Subscription => this.consumer?.Subscription;
 
@@ -99,8 +100,8 @@
 
         private object GetConsumerLogInfo(IEnumerable<TopicPartition> partitions) => new
         {
-            this.configuration.GroupId,
-            this.configuration.ConsumerName,
+            this.Configuration.GroupId,
+            this.Configuration.ConsumerName,
             Topics = partitions
                 .GroupBy(x => x.Topic)
                 .Select(
@@ -143,10 +144,9 @@
                 new MessageConsumer(
                     this,
                     this.consumerWorkerPool,
-                    this.configuration,
                     this.logHandler));
 
-            this.consumer.Subscribe(this.configuration.Topics);
+            this.consumer.Subscribe(this.Configuration.Topics);
 
             this.backgroundTask = Task.Factory.StartNew(
                 async () =>

--- a/src/KafkaFlow/Consumers/KafkaConsumerFlowManager.cs
+++ b/src/KafkaFlow/Consumers/KafkaConsumerFlowManager.cs
@@ -1,0 +1,118 @@
+namespace KafkaFlow.Consumers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Confluent.Kafka;
+
+    internal class KafkaConsumerFlowManager : IKafkaConsumerFlowManager
+    {
+        private readonly IConsumer<byte[], byte[]> consumer;
+        private readonly CancellationToken stopCancellationToken;
+        private readonly ILogHandler logHandler;
+
+        private CancellationTokenSource heartbeatTokenSource;
+        private Task heartbeatTask;
+
+        private readonly List<TopicPartition> pausedPartitions = new List<TopicPartition>();
+
+        public KafkaConsumerFlowManager(
+            IConsumer<byte[], byte[]> consumer,
+            CancellationToken stopCancellationToken,
+            ILogHandler logHandler)
+        {
+            this.consumer = consumer;
+            this.stopCancellationToken = stopCancellationToken;
+            this.logHandler = logHandler;
+        }
+
+        public void Pause(IReadOnlyCollection<TopicPartition> topicPartitions)
+        {
+            lock (this.pausedPartitions)
+            {
+                topicPartitions = topicPartitions.Except(this.pausedPartitions).ToList();
+
+                if (!topicPartitions.Any())
+                {
+                    return;
+                }
+
+                this.consumer.Pause(topicPartitions);
+                this.pausedPartitions.AddRange(topicPartitions);
+
+                if (this.HasRunningPartitions())
+                {
+                    return;
+                }
+
+                this.heartbeatTokenSource = CancellationTokenSource.CreateLinkedTokenSource(this.stopCancellationToken);
+
+                this.heartbeatTask = Task.Run(
+                    () =>
+                    {
+                        const int consumeTimeoutCall = 1000;
+
+                        try
+                        {
+                            while (!this.heartbeatTokenSource.IsCancellationRequested)
+                            {
+                                var result = this.consumer.Consume(consumeTimeoutCall);
+
+                                if (result != null)
+                                {
+                                    this.logHandler.Warning(
+                                        "Paused consumer heartbeat process wrongly read a message, please report this issue",
+                                        null);
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            this.logHandler.Error(
+                                "Error executing paused consumer background heartbeat",
+                                ex,
+                                null);
+                        }
+                    },
+                    this.heartbeatTokenSource.Token);
+            }
+        }
+
+        public void Resume(IReadOnlyCollection<TopicPartition> topicPartitions)
+        {
+            lock (this.pausedPartitions)
+            {
+                if (!topicPartitions.Any())
+                {
+                    return;
+                }
+
+                foreach (var topicPartition in topicPartitions)
+                {
+                    this.pausedPartitions.Remove(topicPartition);
+                }
+
+                if (!this.HasRunningPartitions())
+                {
+                    return;
+                }
+
+                this.heartbeatTokenSource?.Cancel();
+
+                this.heartbeatTask.GetAwaiter().GetResult();
+                this.heartbeatTask.Dispose();
+
+                this.consumer.Resume(topicPartitions);
+            }
+        }
+
+        private bool HasRunningPartitions()
+        {
+            return
+                this.consumer.Assignment.Count != this.pausedPartitions.Count ||
+                this.consumer.Assignment.Except(this.pausedPartitions).Any();
+        }
+    }
+}

--- a/src/KafkaFlow/Consumers/MessageConsumer.cs
+++ b/src/KafkaFlow/Consumers/MessageConsumer.cs
@@ -5,32 +5,28 @@ namespace KafkaFlow.Consumers
     using System.Linq;
     using System.Threading.Tasks;
     using Confluent.Kafka;
-    using KafkaFlow.Configuration;
 
     internal class MessageConsumer : IMessageConsumer
     {
         private readonly IKafkaConsumer consumer;
         private readonly IConsumerWorkerPool workerPool;
-        private readonly ConsumerConfiguration configuration;
         private readonly ILogHandler logHandler;
 
         public MessageConsumer(
             IKafkaConsumer consumer,
             IConsumerWorkerPool workerPool,
-            ConsumerConfiguration configuration,
             ILogHandler logHandler)
         {
             this.workerPool = workerPool;
-            this.configuration = configuration;
             this.logHandler = logHandler;
             this.consumer = consumer;
         }
 
-        public string ConsumerName => this.configuration.ConsumerName;
+        public string ConsumerName => this.consumer.Configuration.ConsumerName;
 
-        public string GroupId => this.configuration.GroupId;
+        public string GroupId => this.consumer.Configuration.GroupId;
 
-        public int WorkerCount => this.configuration.WorkerCount;
+        public int WorkerCount => this.consumer.Configuration.WorkerCount;
 
         public async Task OverrideOffsetsAndRestartAsync(IReadOnlyCollection<TopicPartitionOffset> offsets)
         {
@@ -76,7 +72,8 @@ namespace KafkaFlow.Consumers
 
         public async Task ChangeWorkerCountAndRestartAsync(int workerCount)
         {
-            this.configuration.WorkerCount = workerCount;
+            this.consumer.Configuration.WorkerCount = workerCount;
+
             await this.InternalRestart().ConfigureAwait(false);
 
             this.logHandler.Info(

--- a/src/KafkaFlow/Consumers/MessageConsumer.cs
+++ b/src/KafkaFlow/Consumers/MessageConsumer.cs
@@ -37,7 +37,7 @@ namespace KafkaFlow.Consumers
 
             try
             {
-                this.consumer.Pause(this.consumer.Assignment);
+                this.consumer.FlowManager.Pause(this.consumer.Assignment);
                 await this.workerPool.StopAsync().ConfigureAwait(false);
 
                 this.consumer.Commit(offsets);
@@ -102,11 +102,11 @@ namespace KafkaFlow.Consumers
 
         public string ClientInstanceName => this.consumer.ClientInstanceName;
 
-        public void Pause(IEnumerable<TopicPartition> topicPartitions) =>
-            this.consumer.Pause(topicPartitions);
+        public void Pause(IReadOnlyCollection<TopicPartition> topicPartitions) =>
+            this.consumer.FlowManager.Pause(topicPartitions);
 
-        public void Resume(IEnumerable<TopicPartition> topicPartitions) =>
-            this.consumer.Resume(topicPartitions);
+        public void Resume(IReadOnlyCollection<TopicPartition> topicPartitions) =>
+            this.consumer.FlowManager.Resume(topicPartitions);
 
         public Offset GetPosition(TopicPartition topicPartition) =>
             this.consumer.GetPosition(topicPartition);

--- a/src/KafkaFlow/Consumers/MessageContextConsumer.cs
+++ b/src/KafkaFlow/Consumers/MessageContextConsumer.cs
@@ -12,19 +12,17 @@ namespace KafkaFlow.Consumers
 
         public MessageContextConsumer(
             IKafkaConsumer consumer,
-            string name,
             IOffsetManager offsetManager,
             ConsumeResult<byte[], byte[]> kafkaResult,
             CancellationToken workerStopped)
         {
-            this.Name = name;
             this.WorkerStopped = workerStopped;
             this.consumer = consumer;
             this.offsetManager = offsetManager;
             this.kafkaResult = kafkaResult;
         }
 
-        public string Name { get; }
+        public string Name => this.consumer.Configuration.ConsumerName;
 
         public CancellationToken WorkerStopped { get; }
 

--- a/src/KafkaFlow/Consumers/MessageContextConsumer.cs
+++ b/src/KafkaFlow/Consumers/MessageContextConsumer.cs
@@ -42,12 +42,12 @@ namespace KafkaFlow.Consumers
 
         public void Pause()
         {
-            this.consumer.Pause(this.consumer.Assignment);
+            this.consumer.FlowManager.Pause(this.consumer.Assignment);
         }
 
         public void Resume()
         {
-            this.consumer.Resume(this.consumer.Assignment);
+            this.consumer.FlowManager.Resume(this.consumer.Assignment);
         }
     }
 }

--- a/src/KafkaFlow/KafkaBus.cs
+++ b/src/KafkaFlow/KafkaBus.cs
@@ -46,7 +46,6 @@ namespace KafkaFlow
 
                 var consumerWorkerPool = new ConsumerWorkerPool(
                     dependencyScope.Resolver,
-                    consumerConfiguration,
                     this.logHandler,
                     new MiddlewareExecutor(middlewares),
                     consumerConfiguration.DistributionStrategyFactory);

--- a/src/KafkaFlow/Producers/BatchProduceExtension.cs
+++ b/src/KafkaFlow/Producers/BatchProduceExtension.cs
@@ -118,10 +118,17 @@ namespace KafkaFlow.Producers
         }
     }
 
+    /// <summary>
+    /// </summary>
     public class BatchProduceException : Exception
     {
+        /// <summary>
+        /// </summary>
         public IReadOnlyCollection<BatchProduceItem> Items { get; }
 
+        /// <summary>
+        /// </summary>
+        /// <param name="items"></param>
         public BatchProduceException(IReadOnlyCollection<BatchProduceItem> items)
         {
             this.Items = items;

--- a/src/KafkaFlow/Producers/BatchProduceExtension.cs
+++ b/src/KafkaFlow/Producers/BatchProduceExtension.cs
@@ -119,14 +119,17 @@ namespace KafkaFlow.Producers
     }
 
     /// <summary>
+    /// Exception thrown by <see cref="BatchProduceExtension.BatchProduceAsync"/>
     /// </summary>
     public class BatchProduceException : Exception
     {
         /// <summary>
+        /// The requested items to produce with <see cref="BatchProduceItem.DeliveryReport"/> filled
         /// </summary>
         public IReadOnlyCollection<BatchProduceItem> Items { get; }
 
         /// <summary>
+        /// Creates a <see cref="BatchProduceException"/>
         /// </summary>
         /// <param name="items"></param>
         public BatchProduceException(IReadOnlyCollection<BatchProduceItem> items)


### PR DESCRIPTION
# Description

Creates a background Task to send heartbeats to Kafka when the entire consumer is paused

Fixes #111 


## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
