### PR TITLE
fix: fix ConsoleLogHandler when serializing exceptions

### DIFF
--- a/src/KafkaFlow.LogHandler.Console/ConsoleLogHandler.cs
+++ b/src/KafkaFlow.LogHandler.Console/ConsoleLogHandler.cs
@@ -5,9 +5,20 @@
 
     internal class ConsoleLogHandler : ILogHandler
     {
-        public void Error(string message, Exception ex, object data) => Print(
-            $"\nKafkaFlow: {message} | Data: {JsonSerializer.Serialize(data)} | Exception: {JsonSerializer.Serialize(ex)}",
-            ConsoleColor.Red);
+        public void Error(string message, Exception ex, object data)
+        {
+            var serializedException = JsonSerializer.Serialize(
+                new
+                {
+                    Type = ex.GetType().FullName,
+                    ex.Message,
+                    ex.StackTrace
+                });
+
+            Print(
+                $"\nKafkaFlow: {message} | Data: {JsonSerializer.Serialize(data)} | Exception: {serializedException}",
+                ConsoleColor.Red);
+        }
 
         public void Info(string message, object data) => Print(
             $"\nKafkaFlow: {message} | Data: {JsonSerializer.Serialize(data)}",


### PR DESCRIPTION
# Description

Today we have a problem serializing exception inside ConsoleLogHandler, this pull request changes how we serialize them to fix it.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
