### PR TITLE
feat: allow client to use a custom producer and consumer factory

### DIFF
--- a/src/KafkaFlow.UnitTests/ConfigurationBuilders/ConsumerConfigurationBuilderTests.cs
+++ b/src/KafkaFlow.UnitTests/ConfigurationBuilders/ConsumerConfigurationBuilderTests.cs
@@ -1,0 +1,126 @@
+namespace KafkaFlow.UnitTests.ConfigurationBuilders
+{
+    using System;
+    using AutoFixture;
+    using Confluent.Kafka;
+    using FluentAssertions;
+    using KafkaFlow.Configuration;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using AutoOffsetReset = KafkaFlow.AutoOffsetReset;
+
+    [TestClass]
+    public class ConsumerConfigurationBuilderTests
+    {
+        private readonly Fixture fixture = new Fixture();
+
+        private Mock<IDependencyConfigurator> dependencyConfiguratorMock;
+
+        private ConsumerConfigurationBuilder target;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.dependencyConfiguratorMock = new Mock<IDependencyConfigurator>();
+
+            this.target = new ConsumerConfigurationBuilder(this.dependencyConfiguratorMock.Object);
+        }
+
+        [TestMethod]
+        public void DependencyConfigurator_SetProperty_ReturnPassedInstance()
+        {
+            // Assert
+            this.target.DependencyConfigurator.Should().Be(this.dependencyConfiguratorMock.Object);
+        }
+
+        [TestMethod]
+        public void Build_RequiredCalls_ReturnDefaultValues()
+        {
+            // Arrange
+            var clusterConfiguration = this.fixture.Create<ClusterConfiguration>();
+            var topic1 = this.fixture.Create<string>();
+            const int bufferSize = 100;
+            const int workers = 10;
+            var groupId = this.fixture.Create<string>();
+
+            this.target
+                .Topics(topic1)
+                .WithBufferSize(bufferSize)
+                .WithWorkersCount(workers)
+                .WithGroupId(groupId);
+
+            // Act
+            var configuration = this.target.Build(clusterConfiguration);
+
+            // Assert
+            configuration.Topics.Should().BeEquivalentTo(topic1);
+            configuration.BufferSize.Should().Be(bufferSize);
+            configuration.WorkerCount.Should().Be(workers);
+            configuration.GroupId.Should().Be(groupId);
+            configuration.GetKafkaConfig().AutoOffsetReset.Should().BeNull();
+            configuration.GetKafkaConfig().EnableAutoOffsetStore.Should().Be(false);
+            configuration.GetKafkaConfig().EnableAutoCommit.Should().Be(false);
+            configuration.AutoStoreOffsets.Should().Be(true);
+            configuration.AutoCommitInterval.Should().Be(TimeSpan.FromSeconds(5));
+            configuration.StatisticsHandlers.Should().BeEmpty();
+            configuration.MiddlewareConfiguration.Factories.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void Build_AllCalls_ReturnPassedValues()
+        {
+            // Arrange
+            var clusterConfiguration = this.fixture.Create<ClusterConfiguration>();
+            var topic1 = this.fixture.Create<string>();
+            var topic2 = this.fixture.Create<string>();
+            var name = this.fixture.Create<string>();
+            const int bufferSize = 100;
+            const int workers = 10;
+            const AutoOffsetReset offsetReset = AutoOffsetReset.Earliest;
+            var groupId = this.fixture.Create<string>();
+            const int autoCommitInterval = 10000;
+            const int maxPollIntervalMs = 500000;
+            ConsumerCustomFactory customFactory = (producer, resolver) => producer;
+            Action<string> statisticsHandler = s => { };
+            const int statisticsIntervalMs = 100;
+            var consumerConfig = new ConsumerConfig();
+
+            this.target
+                .Topics(topic1)
+                .Topic(topic2)
+                .WithName(name)
+                .WithBufferSize(bufferSize)
+                .WithWorkersCount(workers)
+                .WithGroupId(groupId)
+                .WithAutoOffsetReset(offsetReset)
+                .WithManualStoreOffsets()
+                .WithAutoCommitIntervalMs(autoCommitInterval)
+                .WithMaxPollIntervalMs(maxPollIntervalMs)
+                .WithConsumerConfig(consumerConfig)
+                .WithCustomFactory(customFactory)
+                .WithStatisticsIntervalMs(statisticsIntervalMs)
+                .WithStatisticsHandler(statisticsHandler)
+                .AddMiddlewares(m => m.Add<IMessageMiddleware>());
+
+            // Act
+            var configuration = this.target.Build(clusterConfiguration);
+
+            // Assert
+            configuration.Topics.Should().BeEquivalentTo(topic1, topic2);
+            configuration.ConsumerName.Should().Be(name);
+            configuration.BufferSize.Should().Be(bufferSize);
+            configuration.WorkerCount.Should().Be(workers);
+            configuration.GroupId.Should().Be(groupId);
+            configuration.GetKafkaConfig().AutoOffsetReset.Should().Be(offsetReset);
+            configuration.AutoStoreOffsets.Should().Be(false);
+            configuration.GetKafkaConfig().EnableAutoOffsetStore.Should().Be(false);
+            configuration.GetKafkaConfig().EnableAutoCommit.Should().Be(false);
+            configuration.AutoCommitInterval.Should().Be(TimeSpan.FromMilliseconds(autoCommitInterval));
+            configuration.GetKafkaConfig().MaxPollIntervalMs.Should().Be(maxPollIntervalMs);
+            configuration.GetKafkaConfig().StatisticsIntervalMs.Should().Be(statisticsIntervalMs);
+            configuration.StatisticsHandlers.Should().HaveElementAt(0, statisticsHandler);
+            configuration.GetKafkaConfig().Should().BeSameAs(consumerConfig);
+            configuration.MiddlewareConfiguration.Factories.Should().HaveCount(1);
+        }
+    }
+}

--- a/src/KafkaFlow.UnitTests/ConfigurationBuilders/ProducerConfigurationBuilderTests.cs
+++ b/src/KafkaFlow.UnitTests/ConfigurationBuilders/ProducerConfigurationBuilderTests.cs
@@ -1,0 +1,97 @@
+namespace KafkaFlow.UnitTests.ConfigurationBuilders
+{
+    using System;
+    using AutoFixture;
+    using Confluent.Kafka;
+    using FluentAssertions;
+    using KafkaFlow.Configuration;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class ProducerConfigurationBuilderTests
+    {
+        private readonly Fixture fixture = new Fixture();
+
+        private Mock<IDependencyConfigurator> dependencyConfiguratorMock;
+
+        private string name;
+
+        private ProducerConfigurationBuilder target;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.dependencyConfiguratorMock = new Mock<IDependencyConfigurator>();
+            this.name = this.fixture.Create<string>();
+
+            this.target = new ProducerConfigurationBuilder(
+                this.dependencyConfiguratorMock.Object,
+                this.name);
+        }
+
+        [TestMethod]
+        public void DependencyConfigurator_SetProperty_ReturnPassedInstance()
+        {
+            // Assert
+            this.target.DependencyConfigurator.Should().Be(this.dependencyConfiguratorMock.Object);
+        }
+
+        [TestMethod]
+        public void Build_RequiredCalls_ReturnDefaultValues()
+        {
+            // Arrange
+            var clusterConfiguration = this.fixture.Create<ClusterConfiguration>();
+
+            // Act
+            var configuration = this.target.Build(clusterConfiguration);
+
+            // Assert
+            configuration.Cluster.Should().Be(clusterConfiguration);
+            configuration.Name.Should().Be(this.name);
+            configuration.DefaultTopic.Should().BeNull();
+            configuration.Acks.Should().BeNull();
+            configuration.StatisticsHandlers.Should().BeEmpty();
+            configuration.MiddlewareConfiguration.Factories.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void Build_AllCalls_ReturnPassedValues()
+        {
+            // Arrange
+            var clusterConfiguration = this.fixture.Create<ClusterConfiguration>();
+
+            var defaultTopic = this.fixture.Create<string>();
+            var acks = this.fixture.Create<KafkaFlow.Acks>();
+            const int lingerMs = 50;
+            ProducerCustomFactory customFactory = (producer, resolver) => producer;
+            Action<string> statisticsHandler = s => { };
+            const int statisticsIntervalMs = 100;
+            var producerConfig = new ProducerConfig();
+
+            this.target
+                .DefaultTopic(defaultTopic)
+                .WithAcks(acks)
+                .WithLingerMs(lingerMs)
+                .WithCustomFactory(customFactory)
+                .WithStatisticsHandler(statisticsHandler)
+                .WithStatisticsIntervalMs(statisticsIntervalMs)
+                .WithProducerConfig(producerConfig)
+                .AddMiddlewares(m => m.Add<IMessageMiddleware>());
+
+            // Act
+            var configuration = this.target.Build(clusterConfiguration);
+
+            // Assert
+            configuration.Cluster.Should().Be(clusterConfiguration);
+            configuration.Name.Should().Be(this.name);
+            configuration.DefaultTopic.Should().Be(defaultTopic);
+            configuration.Acks.Should().Be(acks);
+            configuration.BaseProducerConfig.LingerMs.Should().Be(lingerMs);
+            configuration.BaseProducerConfig.StatisticsIntervalMs.Should().Be(statisticsIntervalMs);
+            configuration.StatisticsHandlers.Should().HaveElementAt(0, statisticsHandler);
+            configuration.BaseProducerConfig.Should().BeSameAs(producerConfig);
+            configuration.MiddlewareConfiguration.Factories.Should().HaveCount(1);
+        }
+    }
+}

--- a/src/KafkaFlow.UnitTests/KafkaFlow.UnitTests.csproj
+++ b/src/KafkaFlow.UnitTests/KafkaFlow.UnitTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
@@ -19,7 +19,8 @@ namespace KafkaFlow.Configuration
             MiddlewareConfiguration middlewareConfiguration,
             bool autoStoreOffsets,
             TimeSpan autoCommitInterval,
-            IReadOnlyList<Action<string>> statisticsHandlers)
+            IReadOnlyList<Action<string>> statisticsHandlers,
+            ConsumerCustomFactory customFactory)
         {
             this.consumerConfig = consumerConfig ?? throw new ArgumentNullException(nameof(consumerConfig));
 
@@ -37,6 +38,7 @@ namespace KafkaFlow.Configuration
             this.ConsumerName = consumerName ?? Guid.NewGuid().ToString();
             this.WorkerCount = workerCount;
             this.StatisticsHandlers = statisticsHandlers;
+            this.CustomFactory = customFactory;
 
             this.BufferSize = bufferSize > 0 ?
                 bufferSize :
@@ -75,6 +77,8 @@ namespace KafkaFlow.Configuration
         public TimeSpan AutoCommitInterval { get; }
 
         public IReadOnlyList<Action<string>> StatisticsHandlers { get; }
+
+        public ConsumerCustomFactory CustomFactory { get; }
 
         public ConsumerConfig GetKafkaConfig()
         {

--- a/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
@@ -27,6 +27,8 @@ namespace KafkaFlow.Configuration
         private Factory<IDistributionStrategy> distributionStrategyFactory = resolver => new BytesSumDistributionStrategy();
         private TimeSpan autoCommitInterval = TimeSpan.FromSeconds(5);
 
+        private ConsumerCustomFactory customFactory = (consumer, resolver) => consumer;
+
         public IDependencyConfigurator DependencyConfigurator { get; }
 
         public ConsumerConfigurationBuilder(IDependencyConfigurator dependencyConfigurator)
@@ -152,6 +154,12 @@ namespace KafkaFlow.Configuration
             return this;
         }
 
+        public IConsumerConfigurationBuilder WithCustomFactory(ConsumerCustomFactory customFactory)
+        {
+            this.customFactory = customFactory;
+            return this;
+        }
+
         public ConsumerConfiguration Build(ClusterConfiguration clusterConfiguration)
         {
             var middlewareConfiguration = this.middlewareConfigurationBuilder.Build();
@@ -178,7 +186,8 @@ namespace KafkaFlow.Configuration
                 middlewareConfiguration,
                 this.autoStoreOffsets,
                 this.autoCommitInterval,
-                this.statisticsHandlers);
+                this.statisticsHandlers,
+                this.customFactory);
         }
     }
 }

--- a/src/KafkaFlow/Configuration/ProducerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/ProducerConfiguration.cs
@@ -14,7 +14,8 @@ namespace KafkaFlow.Configuration
             Acks? acks,
             MiddlewareConfiguration middlewareConfiguration,
             ProducerConfig baseProducerConfig,
-            IReadOnlyList<Action<string>> statisticsHandlers)
+            IReadOnlyList<Action<string>> statisticsHandlers,
+            ProducerCustomFactory customFactory)
         {
             this.Cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
             this.Name = name;
@@ -23,6 +24,7 @@ namespace KafkaFlow.Configuration
             this.MiddlewareConfiguration = middlewareConfiguration;
             this.BaseProducerConfig = baseProducerConfig;
             this.StatisticsHandlers = statisticsHandlers;
+            this.CustomFactory = customFactory;
         }
 
         public ClusterConfiguration Cluster { get; }
@@ -38,6 +40,8 @@ namespace KafkaFlow.Configuration
         public MiddlewareConfiguration MiddlewareConfiguration { get; }
 
         public IReadOnlyList<Action<string>> StatisticsHandlers { get; }
+
+        public ProducerCustomFactory CustomFactory { get; }
 
         public ProducerConfig GetKafkaConfig()
         {

--- a/src/KafkaFlow/Configuration/ProducerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ProducerConfigurationBuilder.cs
@@ -16,6 +16,7 @@ namespace KafkaFlow.Configuration
         private Acks? acks;
         private int statisticsInterval;
         private double? lingerMs;
+        private ProducerCustomFactory customFactory = (producer, resolver) => producer; 
 
         public ProducerConfigurationBuilder(IDependencyConfigurator dependencyConfigurator, string name)
         {
@@ -68,6 +69,12 @@ namespace KafkaFlow.Configuration
             return this;
         }
 
+        public IProducerConfigurationBuilder WithCustomFactory(ProducerCustomFactory customFactory)
+        {
+            this.customFactory = customFactory;
+            return this;
+        }
+
         public ProducerConfiguration Build(ClusterConfiguration clusterConfiguration)
         {
             this.producerConfig ??= new ProducerConfig();
@@ -84,7 +91,8 @@ namespace KafkaFlow.Configuration
                 this.acks,
                 this.middlewareConfigurationBuilder.Build(),
                 this.producerConfig,
-                this.statisticsHandlers);
+                this.statisticsHandlers,
+                this.customFactory);
 
             return configuration;
         }

--- a/src/KafkaFlow/Consumers/KafkaConsumer.cs
+++ b/src/KafkaFlow/Consumers/KafkaConsumer.cs
@@ -13,6 +13,7 @@
         private readonly IConsumerManager consumerManager;
         private readonly ILogHandler logHandler;
         private readonly IConsumerWorkerPool consumerWorkerPool;
+        private readonly IDependencyResolver dependencyResolver;
         private readonly CancellationToken busStopCancellationToken;
 
         private readonly ConsumerBuilder<byte[], byte[]> consumerBuilder;
@@ -27,12 +28,14 @@
             IConsumerManager consumerManager,
             ILogHandler logHandler,
             IConsumerWorkerPool consumerWorkerPool,
+            IDependencyResolver dependencyResolver,
             CancellationToken busStopCancellationToken)
         {
             this.Configuration = configuration;
             this.consumerManager = consumerManager;
             this.logHandler = logHandler;
             this.consumerWorkerPool = consumerWorkerPool;
+            this.dependencyResolver = dependencyResolver;
             this.busStopCancellationToken = busStopCancellationToken;
 
             var kafkaConfig = configuration.GetKafkaConfig();
@@ -140,7 +143,10 @@
 
         private void CreateConsumerAndBackgroundTask()
         {
-            this.consumer = this.consumerBuilder.Build();
+            this.consumer = this.Configuration.CustomFactory(
+                this.consumerBuilder.Build(),
+                this.dependencyResolver);
+
             this.FlowManager = new KafkaConsumerFlowManager(
                 this.consumer,
                 this.stopCancellationTokenSource.Token,

--- a/src/KafkaFlow/Delegates.cs
+++ b/src/KafkaFlow/Delegates.cs
@@ -1,0 +1,22 @@
+namespace KafkaFlow
+{
+    using Confluent.Kafka;
+
+    /// <summary>
+    /// A factory to decorates the consumer created by KafkaFlow
+    /// </summary>
+    /// <param name="consumer">The consumer created by KafkaFlow</param>
+    /// <param name="resolver">The <see cref="IDependencyResolver"/> to get registered services</param>
+    public delegate IConsumer<byte[], byte[]> ConsumerCustomFactory(
+        IConsumer<byte[], byte[]> consumer,
+        IDependencyResolver resolver);
+
+    /// <summary>
+    /// A factory to decorates the producer created by KafkaFlow
+    /// </summary>
+    /// <param name="producer">The producer created by KafkaFlow</param>
+    /// <param name="resolver">The <see cref="IDependencyResolver"/> to get registered services</param>
+    public delegate IProducer<byte[], byte[]> ProducerCustomFactory(
+        IProducer<byte[], byte[]> producer,
+        IDependencyResolver resolver);
+}

--- a/src/KafkaFlow/Extensions/ConfigurationBuilderExtensions.cs
+++ b/src/KafkaFlow/Extensions/ConfigurationBuilderExtensions.cs
@@ -16,8 +16,7 @@ namespace KafkaFlow
         /// <returns></returns>
         public static IProducerConfigurationBuilder WithProducerConfig(this IProducerConfigurationBuilder builder, ProducerConfig config)
         {
-            ((ProducerConfigurationBuilder) builder).WithProducerConfig(config);
-            return builder;
+            return ((ProducerConfigurationBuilder) builder).WithProducerConfig(config);
         }
 
         /// <summary>
@@ -28,8 +27,33 @@ namespace KafkaFlow
         /// <returns></returns>
         public static IConsumerConfigurationBuilder WithConsumerConfig(this IConsumerConfigurationBuilder builder, ConsumerConfig config)
         {
-            ((ConsumerConfigurationBuilder)builder).WithConsumerConfig(config);
-            return builder;
+            return ((ConsumerConfigurationBuilder) builder).WithConsumerConfig(config);
+        }
+
+        /// <summary>
+        /// Register a custom consumer factory to be internally used by the framework
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="decoratorFactory">The factory method</param>
+        /// <returns></returns>
+        public static IConsumerConfigurationBuilder WithCustomFactory(
+            this IConsumerConfigurationBuilder builder,
+            ConsumerCustomFactory decoratorFactory)
+        {
+            return ((ConsumerConfigurationBuilder) builder).WithCustomFactory(decoratorFactory);
+        }
+
+        /// <summary>
+        /// Register a custom producer factory to be internally used by the framework
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="decoratorFactory">The factory method</param>
+        /// <returns></returns>
+        public static IProducerConfigurationBuilder WithCustomFactory(
+            this IProducerConfigurationBuilder builder,
+            ProducerCustomFactory decoratorFactory)
+        {
+            return ((ProducerConfigurationBuilder) builder).WithCustomFactory(decoratorFactory);
         }
     }
 }

--- a/src/KafkaFlow/KafkaBus.cs
+++ b/src/KafkaFlow/KafkaBus.cs
@@ -55,6 +55,7 @@ namespace KafkaFlow
                     this.consumerManager,
                     this.logHandler,
                     consumerWorkerPool,
+                    this.dependencyResolver,
                     stopCancellationToken);
 
                 this.consumers.Add(consumer);

--- a/src/KafkaFlow/Producers/MessageProducer.cs
+++ b/src/KafkaFlow/Producers/MessageProducer.cs
@@ -153,7 +153,7 @@ namespace KafkaFlow.Producers
                     return this.producer;
                 }
 
-                return this.producer = new ProducerBuilder<byte[], byte[]>(this.configuration.GetKafkaConfig())
+                var producerBuilder = new ProducerBuilder<byte[], byte[]>(this.configuration.GetKafkaConfig())
                     .SetErrorHandler(
                         (p, error) =>
                         {
@@ -168,14 +168,18 @@ namespace KafkaFlow.Producers
                                     .Warning("Kafka Producer Error", new { Error = error });
                             }
                         })
-                    .SetStatisticsHandler((producer, statistics) =>
-                    {
-                        foreach (var handler in this.configuration.StatisticsHandlers)
+                    .SetStatisticsHandler(
+                        (producer, statistics) =>
                         {
-                            handler.Invoke(statistics);
-                        }
-                    })
-                    .Build();
+                            foreach (var handler in this.configuration.StatisticsHandlers)
+                            {
+                                handler.Invoke(statistics);
+                            }
+                        });
+
+                return this.producer = this.configuration.CustomFactory(
+                    producerBuilder.Build(),
+                    this.dependencyResolverScope.Resolver);
             }
         }
 


### PR DESCRIPTION
# Description

Creates method WithCustomFactory() that allows the client app to use custom instances of producers and consumers.

Closes #107 

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
