### PR TITLE
fix: compare both datetime values in UTC format

### DIFF
--- a/src/KafkaFlow.UnitTests/MessageContextConsumerTests.cs
+++ b/src/KafkaFlow.UnitTests/MessageContextConsumerTests.cs
@@ -30,7 +30,7 @@
             var messageTimestamp = target.MessageTimestamp;
 
             // Assert
-            messageTimestamp.Should().Be(expectedMessageTimestamp);
+            messageTimestamp.Should().Be(expectedMessageTimestamp.ToUniversalTime());
         }
     }
 }


### PR DESCRIPTION
# Description

UnitTest 'MessageContextConsumerTests.MessageTimestamp_ConsumeResultHasMessageTimestamp_ReturnsMessageTimestampFromResult' is failing because compares a local datetime with an UTC datetime.

Now the unit test is comparing both datetimes in the same format (UTC)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
