### PR TITLE
feat: add native compression support

### DIFF
--- a/samples/KafkaFlow.Sample/Program.cs
+++ b/samples/KafkaFlow.Sample/Program.cs
@@ -3,16 +3,17 @@
     using System;
     using System.Linq;
     using System.Threading.Tasks;
+    using Confluent.Kafka;
     using global::Microsoft.Extensions.DependencyInjection;
     using KafkaFlow.Admin;
     using KafkaFlow.Admin.Messages;
-    using KafkaFlow.Compressor;
-    using KafkaFlow.Compressor.Gzip;
     using KafkaFlow.Consumers;
     using KafkaFlow.Producers;
     using KafkaFlow.Serializer;
     using KafkaFlow.Serializer.ProtoBuf;
     using KafkaFlow.TypedHandler;
+    using Acks = KafkaFlow.Acks;
+    using AutoOffsetReset = KafkaFlow.AutoOffsetReset;
 
     internal static class Program
     {
@@ -35,10 +36,10 @@
                                 producerName,
                                 producer => producer
                                     .DefaultTopic("test-topic")
+                                    .WithCompression(CompressionType.Gzip)
                                     .AddMiddlewares(
                                         middlewares => middlewares
                                             .AddSerializer<ProtobufMessageSerializer>()
-                                            .AddCompressor<GzipMessageCompressor>()
                                     )
                                     .WithAcks(Acks.All)
                             )
@@ -52,7 +53,6 @@
                                     .WithAutoOffsetReset(AutoOffsetReset.Latest)
                                     .AddMiddlewares(
                                         middlewares => middlewares
-                                            .AddCompressor<GzipMessageCompressor>()
                                             .AddSerializer<ProtobufMessageSerializer>()
                                             .AddTypedHandlers(
                                                 handlers => handlers

--- a/src/KafkaFlow.Compressor.Gzip/GzipMessageCompressor.cs
+++ b/src/KafkaFlow.Compressor.Gzip/GzipMessageCompressor.cs
@@ -5,7 +5,7 @@
 
     /// <summary>
     /// A GZIP message compressor
-    /// </summary>    
+    /// </summary>
     public class GzipMessageCompressor : IMessageCompressor
     {
         /// <summary>Compress the given message into gzip format</summary>

--- a/src/KafkaFlow.Compressor/ConfigurationBuilderExtensions.cs
+++ b/src/KafkaFlow.Compressor/ConfigurationBuilderExtensions.cs
@@ -33,6 +33,7 @@
 
         /// <summary>
         /// Registers a middleware to compress the message
+        /// It is highly recommended to use the producer native compression ('WithCompression()' method) instead of using the compressor middleware
         /// </summary>
         /// <typeparam name="T">A class that implements <see cref="IMessageCompressor"/></typeparam>
         public static IProducerMiddlewareConfigurationBuilder AddCompressor<T>(this IProducerMiddlewareConfigurationBuilder middlewares)
@@ -44,6 +45,7 @@
 
         /// <summary>
         /// Registers a middleware to compress the message
+        /// It is highly recommended to use the producer native compression ('WithCompression()' method) instead of using the compressor middleware
         /// </summary>
         /// <param name="middlewares"></param>
         /// <param name="factory">A factory to create the <see cref="IMessageCompressor"/> instance</param>

--- a/src/KafkaFlow.IntegrationTests/Core/Bootstrapper.cs
+++ b/src/KafkaFlow.IntegrationTests/Core/Bootstrapper.cs
@@ -202,7 +202,6 @@ namespace KafkaFlow.IntegrationTests.Core
                                     .WithAutoOffsetReset(AutoOffsetReset.Latest)
                                     .AddMiddlewares(
                                         middlewares => middlewares
-                                            .AddCompressor(r => new GzipMessageCompressor())
                                             .AddSerializer(r => new JsonMessageSerializer())
                                             .AddTypedHandlers(
                                                 handlers =>
@@ -241,10 +240,10 @@ namespace KafkaFlow.IntegrationTests.Core
                             .AddProducer<JsonGzipProducer>(
                                 producer => producer
                                     .DefaultTopic(JsonGzipTopicName)
+                                    .WithCompression(CompressionType.Gzip)
                                     .AddMiddlewares(
                                         middlewares => middlewares
                                             .AddSerializer<JsonMessageSerializer>()
-                                            .AddCompressor<GzipMessageCompressor>()
                                     )
                             )
                             .AddProducer<ProtobufProducer>(

--- a/src/KafkaFlow.UnitTests/ConfigurationBuilders/ProducerConfigurationBuilderTests.cs
+++ b/src/KafkaFlow.UnitTests/ConfigurationBuilders/ProducerConfigurationBuilderTests.cs
@@ -68,6 +68,8 @@ namespace KafkaFlow.UnitTests.ConfigurationBuilders
             Action<string> statisticsHandler = s => { };
             const int statisticsIntervalMs = 100;
             var producerConfig = new ProducerConfig();
+            var compressionType = CompressionType.Lz4;
+            var compressionLevel = 5;
 
             this.target
                 .DefaultTopic(defaultTopic)
@@ -77,6 +79,7 @@ namespace KafkaFlow.UnitTests.ConfigurationBuilders
                 .WithStatisticsHandler(statisticsHandler)
                 .WithStatisticsIntervalMs(statisticsIntervalMs)
                 .WithProducerConfig(producerConfig)
+                .WithCompression(compressionType, compressionLevel)
                 .AddMiddlewares(m => m.Add<IMessageMiddleware>());
 
             // Act
@@ -88,6 +91,8 @@ namespace KafkaFlow.UnitTests.ConfigurationBuilders
             configuration.DefaultTopic.Should().Be(defaultTopic);
             configuration.Acks.Should().Be(acks);
             configuration.BaseProducerConfig.LingerMs.Should().Be(lingerMs);
+            configuration.BaseProducerConfig.CompressionType.Should().Be(compressionType);
+            configuration.BaseProducerConfig.CompressionLevel.Should().Be(compressionLevel);
             configuration.BaseProducerConfig.StatisticsIntervalMs.Should().Be(statisticsIntervalMs);
             configuration.StatisticsHandlers.Should().HaveElementAt(0, statisticsHandler);
             configuration.BaseProducerConfig.Should().BeSameAs(producerConfig);

--- a/src/KafkaFlow/Configuration/ProducerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ProducerConfigurationBuilder.cs
@@ -45,6 +45,14 @@ namespace KafkaFlow.Configuration
             return this;
         }
 
+        public IProducerConfigurationBuilder WithCompression(CompressionType compressionType, int? compressionLevel)
+        {
+            this.producerConfig ??= new ProducerConfig();
+            this.producerConfig.CompressionType = compressionType;
+            this.producerConfig.CompressionLevel = compressionLevel;
+            return this;
+        }
+
         public IProducerConfigurationBuilder WithAcks(Acks acks)
         {
             this.acks = acks;

--- a/src/KafkaFlow/Extensions/ConfigurationBuilderExtensions.cs
+++ b/src/KafkaFlow/Extensions/ConfigurationBuilderExtensions.cs
@@ -20,6 +20,28 @@ namespace KafkaFlow
         }
 
         /// <summary>
+        /// Sets compression configurations in the producer 
+        /// </summary>
+        /// <param name="builder">A class that implements <see cref="IProducerConfigurationBuilder"/></param>
+        /// <param name="compressionType">
+        /// <see cref="P:Confluent.Kafka.CompressionType"/> enum to select the compression codec to use for compressing message sets. This is the default value for all topics, may be overridden by the topic configuration property `compression.codec`.
+        /// default: none
+        /// importance: medium</param>
+        /// <param name="compressionLevel">
+        /// Compression level parameter for algorithm selected by <see cref="P:Confluent.Kafka.CompressionType"/> enum. Higher values will result in better compression at the cost of more CPU usage. Usable range is algorithm-dependent: [0-9] for gzip; [0-12] for lz4; only 0 for snappy; -1 = codec-dependent default compression level.
+        /// default: -1
+        /// importance: medium
+        /// </param>
+        /// <returns></returns>
+        public static IProducerConfigurationBuilder WithCompression(
+            this IProducerConfigurationBuilder builder,
+            CompressionType compressionType, 
+            int? compressionLevel = null)
+        {
+            return ((ProducerConfigurationBuilder) builder).WithCompression(compressionType, compressionLevel);
+        }
+
+        /// <summary>
         /// Sets configurations in the consumer based on a <see cref="P:Confluent.Kafka.ConsumerConfig"/> instance 
         /// </summary>
         /// <param name="builder">A class that implements <see cref="IConsumerConfigurationBuilder"/></param>


### PR DESCRIPTION
# Description

This PR adds a [syntax sugar](https://en.wikipedia.org/wiki/Syntactic_sugar#:~:text=In%20computer%20science%2C%20syntactic%20sugar,style%20that%20some%20may%20prefer.) to use native compression available on the confluence driver and marks GzipMiddlewareCompressor as Deprecated.

Fixes https://github.com/Farfetch/kafka-flow/issues/130

## How Has This Been Tested?

Unit and integration tests 

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
