### PR TITLE
Improve JSON Memory Usage & Fix Async Startup Behaviour

### DIFF
--- a/src/KafkaFlow.Serializer.Json/JsonMessageSerializer.cs
+++ b/src/KafkaFlow.Serializer.Json/JsonMessageSerializer.cs
@@ -30,8 +30,7 @@
         /// <returns>A UTF8 JSON string</returns>
         public byte[] Serialize(object message)
         {
-            var serialized = JsonSerializer.Serialize(message, this.options);
-            return Encoding.UTF8.GetBytes(serialized);
+            return JsonSerializer.SerializeToUtf8Bytes(message, this.options);
         }
 
         /// <summary>Deserialize the message</summary>
@@ -40,9 +39,7 @@
         /// <returns>An instance of the passed type</returns>
         public object Deserialize(byte[] data, Type type)
         {
-            var json = Encoding.UTF8.GetString(data);
-
-            return JsonSerializer.Deserialize(json, type, this.options);
+            return JsonSerializer.Deserialize(data, type, this.options);
         }
     }
 }

--- a/src/KafkaFlow/Consumers/ConsumerWorker.cs
+++ b/src/KafkaFlow/Consumers/ConsumerWorker.cs
@@ -47,7 +47,7 @@ namespace KafkaFlow.Consumers
         {
             this.stopCancellationTokenSource = new CancellationTokenSource();
 
-            this.backgroundTask = Task.Factory.StartNew(
+            this.backgroundTask = Task.Run(
                 async () =>
                 {
                     while (!this.stopCancellationTokenSource.IsCancellationRequested)
@@ -102,10 +102,7 @@ namespace KafkaFlow.Consumers
                             // Ignores the exception
                         }
                     }
-                },
-                CancellationToken.None,
-                TaskCreationOptions.LongRunning,
-                TaskScheduler.Default);
+                });
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
# Description

This project looks great! I've looked through some of the code and spotted a couple of improvements.

- Use `System.Text.Json` UTF8 memory overloads to reduce unnecessary string copying.
- The `WorkerPoolFeeder` start task was never really being stopped properly when the stop method was called. Stop was basically a no-op so the tests would finish immediately and the mock verification would pass when then should have been failing. Stopping could rely entirely on cooperative cancellation, and the `WithCancellation` stuff could be removed (it seems overkill to me), however that's a change in behaviour and we'd probably want to delete a couple of tests.

Fixes # (issue)

## How Has This Been Tested?

I've ran the unit tests, which cover the area of code that has been changed.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes (N/A for this change)
-   [ ] I have made corresponding changes to the documentation (N/A for this change)

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
