### PR TITLE
feat: add AddHandlersFromAssemblyOf that accepts multiple marker types

### DIFF
--- a/src/KafkaFlow.IntegrationTests/Core/Bootstrapper.cs
+++ b/src/KafkaFlow.IntegrationTests/Core/Bootstrapper.cs
@@ -32,7 +32,7 @@ namespace KafkaFlow.IntegrationTests.Core
         private const string ProtobufGzipTopicName2 = "test-protobuf-gzip-2";
         private const string AvroTopicName = "test-avro";
         public const string PauseResumeTopicName = "test-pause-resume";
-        
+
         private const string ProtobufGroupId = "consumer-protobuf";
         private const string JsonGroupId = "consumer-json";
         private const string GzipGroupId = "consumer-gzip";
@@ -96,7 +96,7 @@ namespace KafkaFlow.IntegrationTests.Core
                                     .AddMiddlewares(
                                         middlewares => middlewares
                                             .AddSerializer(resolver => new ApacheAvroMessageSerializer(
-                                                resolver, 
+                                                resolver,
                                                 new AvroSerializerConfig
                                                 {
                                                     AutoRegisterSchemas = true,
@@ -150,7 +150,7 @@ namespace KafkaFlow.IntegrationTests.Core
                                     .WithAutoOffsetReset(AutoOffsetReset.Latest)
                                     .WithConsumerConfig(new ConsumerConfig
                                     {
-                                        MaxPollIntervalMs = MaxPollIntervalMs, 
+                                        MaxPollIntervalMs = MaxPollIntervalMs,
                                         SessionTimeoutMs = MaxPollIntervalMs
                                     })
                                     .AddMiddlewares(
@@ -177,7 +177,7 @@ namespace KafkaFlow.IntegrationTests.Core
                                                 handlers =>
                                                     handlers
                                                         .WithHandlerLifetime(InstanceLifetime.Singleton)
-                                                        .AddHandlersFromAssemblyOf<MessageHandler>())
+                                                        .AddHandlersFromAssemblyOf(typeof(Bootstrapper)))
                                     )
                             )
                             .AddConsumer(

--- a/src/KafkaFlow.TypedHandler/TypedHandlerConfigurationBuilder.cs
+++ b/src/KafkaFlow.TypedHandler/TypedHandlerConfigurationBuilder.cs
@@ -3,6 +3,7 @@ namespace KafkaFlow.TypedHandler
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
 
     /// <summary>
     /// Builder class for typed handler configuration
@@ -27,15 +28,20 @@ namespace KafkaFlow.TypedHandler
         /// </summary>
         /// <typeparam name="T">A type that implements the <see cref="IMessageHandler{TMessage}"/> interface</typeparam>
         /// <returns></returns>
-        public TypedHandlerConfigurationBuilder AddHandlersFromAssemblyOf<T>()
-            where T : IMessageHandler
+        public TypedHandlerConfigurationBuilder AddHandlersFromAssemblyOf<T>() => this.AddHandlersFromAssemblyOf(typeof(T));
+
+        /// <summary>
+        /// Adds all classes that implements the <see cref="IMessageHandler{TMessage}"/> interface from the assemblies of the provided types
+        /// </summary>
+        /// <param name="assemblyMarkerTypes"></param>
+        /// <returns></returns>
+        public TypedHandlerConfigurationBuilder AddHandlersFromAssemblyOf(params Type[] assemblyMarkerTypes)
         {
-            var handlersType = typeof(T).Assembly
-                .GetTypes()
+            var handlerTypes = assemblyMarkerTypes
+                .SelectMany(t => t.GetTypeInfo().Assembly.GetTypes())
                 .Where(x => x.IsClass && !x.IsAbstract && typeof(IMessageHandler).IsAssignableFrom(x));
 
-            this.handlers.AddRange(handlersType);
-
+            this.handlers.AddRange(handlerTypes);
             return this;
         }
 


### PR DESCRIPTION
# Description

Add a new `AddHandlersFromAssemblyOf` that accepts multiple marker types.

Fixes #147 

## How Has This Been Tested?

Changed the `Bootstrapper` class in the integration tests to use the new method.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
