### PR TITLE
refactor: mark gzip compressor as obsolete

### DIFF
--- a/src/KafkaFlow.Compressor.Gzip/GzipMessageCompressor.cs
+++ b/src/KafkaFlow.Compressor.Gzip/GzipMessageCompressor.cs
@@ -1,11 +1,13 @@
 ﻿namespace KafkaFlow.Compressor.Gzip
 {
+    using System;
     using System.IO;
     using System.IO.Compression;
 
     /// <summary>
     /// A GZIP message compressor
     /// </summary>
+    [Obsolete("Compressors should only be used in backward compatibility scenarios, in the vast majority of cases native compression (producer.WithCompression()) should be used instead")]
     public class GzipMessageCompressor : IMessageCompressor
     {
         /// <inheritdoc />

--- a/src/KafkaFlow.Compressor/ConfigurationBuilderExtensions.cs
+++ b/src/KafkaFlow.Compressor/ConfigurationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace KafkaFlow.Compressor
 {
+    using System;
     using KafkaFlow.Configuration;
 
     /// <summary>
@@ -13,6 +14,7 @@
         /// <param name="middlewares">The middleware configuration builder</param>
         /// <typeparam name="T">The compressor type</typeparam>
         /// <returns></returns>
+        [Obsolete("Compressors should only be used in backward compatibility scenarios, in the vast majority of cases native compression (producer.WithCompression()) should be used instead")]
         public static IConsumerMiddlewareConfigurationBuilder AddCompressor<T>(this IConsumerMiddlewareConfigurationBuilder middlewares)
             where T : class, IMessageCompressor
         {
@@ -27,6 +29,7 @@
         /// <typeparam name="T">The compressor type that implements <see cref="IMessageCompressor"/></typeparam>
         /// <param name="factory">A factory to create the <see cref="IMessageCompressor"/> instance</param>
         /// <returns></returns>
+        [Obsolete("Compressors should only be used in backward compatibility scenarios, in the vast majority of cases native compression (producer.WithCompression()) should be used instead")]
         public static IConsumerMiddlewareConfigurationBuilder AddCompressor<T>(
             this IConsumerMiddlewareConfigurationBuilder middlewares,
             Factory<T> factory)
@@ -42,6 +45,7 @@
         /// <param name="middlewares">The middleware configuration builder</param>
         /// <typeparam name="T">The compressor type that implements <see cref="IMessageCompressor"/></typeparam>
         /// <returns></returns>
+        [Obsolete("Compressors should only be used in backward compatibility scenarios, in the vast majority of cases native compression (producer.WithCompression()) should be used instead")]
         public static IProducerMiddlewareConfigurationBuilder AddCompressor<T>(this IProducerMiddlewareConfigurationBuilder middlewares)
             where T : class, IMessageCompressor
         {
@@ -57,6 +61,7 @@
         /// <typeparam name="T">The compressor type that implements <see cref="IMessageCompressor"/></typeparam>
         /// <param name="factory">A factory to create the <see cref="IMessageCompressor"/> instance</param>
         /// <returns></returns>
+        [Obsolete("Compressors should only be used in backward compatibility scenarios, in the vast majority of cases native compression (producer.WithCompression()) should be used instead")]
         public static IProducerMiddlewareConfigurationBuilder AddCompressor<T>(
             this IProducerMiddlewareConfigurationBuilder middlewares,
             Factory<T> factory)


### PR DESCRIPTION
# Description

GZIP middleware compressor shouldn't be used anymore but in cases where consumers are receiving messages compressed with it.

The native compression (producer.WithCompression()) should be used instead and this PR marks the GZIP middleware compressor as Obsolete to be able to delete it on v3.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
