### PR TITLE
fix: adds WorkerCount property to MessageConsumer

### DIFF
--- a/src/KafkaFlow/Consumers/MessageConsumer.cs
+++ b/src/KafkaFlow/Consumers/MessageConsumer.cs
@@ -23,6 +23,8 @@ namespace KafkaFlow.Consumers
 
         public string GroupId => this.consumerManager.Consumer.Configuration.GroupId;
 
+        public int WorkerCount => this.consumerManager.Consumer.Configuration.WorkerCount;
+
         public async Task OverrideOffsetsAndRestartAsync(IReadOnlyCollection<TopicPartitionOffset> offsets)
         {
             if (offsets is null)


### PR DESCRIPTION
# Description

This property was originally added in the PR #84 . By mistake it was removed in the PR #123 .

This PR is to fix the issue and add the property again.

Fixes #155 

## How Has This Been Tested?

GET to API consumer endpoint (https://localhost:5001/kafka-flow/groups/TestGroup/consumers/TestConsumer)

## Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
