### PR TITLE
feat(producer): change Produce and ProduceAsync to receive the message key as object

### DIFF
--- a/src/KafkaFlow.IntegrationTests/KafkaFlow.IntegrationTests.csproj
+++ b/src/KafkaFlow.IntegrationTests/KafkaFlow.IntegrationTests.csproj
@@ -6,11 +6,11 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <NoWarn>1701;1702;CS1591;SA1600</NoWarn>
+      <NoWarn>1701;1702;CS1591;SA1600;CS0618</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-      <NoWarn>1701;1702;CS1591;SA1600</NoWarn>
+      <NoWarn>1701;1702;CS1591;SA1600;CS0618</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/KafkaFlow/Producers/BatchProduceExtension.cs
+++ b/src/KafkaFlow/Producers/BatchProduceExtension.cs
@@ -35,8 +35,8 @@ namespace KafkaFlow.Producers
             {
                 producer.Produce(
                     item.Topic,
-                    item.PartitionKey,
-                    item.Message,
+                    item.MessageKey,
+                    item.MessageValue,
                     item.Headers,
                     report =>
                     {

--- a/src/KafkaFlow/Producers/BatchProduceItem.cs
+++ b/src/KafkaFlow/Producers/BatchProduceItem.cs
@@ -11,18 +11,18 @@ namespace KafkaFlow.Producers
         /// Initializes a new instance of the <see cref="BatchProduceItem"/> class.
         /// </summary>
         /// <param name="topic">The destination topic</param>
-        /// <param name="partitionKey">The message partition key</param>
-        /// <param name="message">The message content</param>
+        /// <param name="messageKey">The message partition key</param>
+        /// <param name="messageValue">The message content</param>
         /// <param name="headers">The message headers</param>
         public BatchProduceItem(
             string topic,
-            string partitionKey,
-            object message,
+            object messageKey,
+            object messageValue,
             IMessageHeaders headers)
         {
             this.Topic = topic;
-            this.PartitionKey = partitionKey;
-            this.Message = message;
+            this.MessageKey = messageKey;
+            this.MessageValue = messageValue;
             this.Headers = headers;
         }
 
@@ -34,12 +34,12 @@ namespace KafkaFlow.Producers
         /// <summary>
         /// Gets the message partition key
         /// </summary>
-        public string PartitionKey { get; }
+        public object MessageKey { get; }
 
         /// <summary>
         /// Gets the message object
         /// </summary>
-        public object Message { get; }
+        public object MessageValue { get; }
 
         /// <summary>
         /// Gets the message headers

--- a/src/KafkaFlow/Producers/IMessageProducer.cs
+++ b/src/KafkaFlow/Producers/IMessageProducer.cs
@@ -1,4 +1,4 @@
-namespace KafkaFlow.Producers
+namespace KafkaFlow
 {
     using System;
     using System.Threading.Tasks;
@@ -26,26 +26,26 @@ namespace KafkaFlow.Producers
         /// Produces a new message
         /// </summary>
         /// <param name="topic">The topic where the message wil be produced</param>
-        /// <param name="partitionKey">The message partition key, the value will be encoded suing UTF8</param>
-        /// <param name="message">The message object to be encoded or serialized</param>
+        /// <param name="messageKey">The message key</param>
+        /// <param name="messageValue">The message value</param>
         /// <param name="headers">The message headers</param>
         /// <returns></returns>
         Task<DeliveryResult<byte[], byte[]>> ProduceAsync(
             string topic,
-            string partitionKey,
-            object message,
+            object messageKey,
+            object messageValue,
             IMessageHeaders headers = null);
 
         /// <summary>
         /// Produces a new message in the configured default topic
         /// </summary>
-        /// <param name="partitionKey">The message partition key, the value will be encoded suing UTF8</param>
-        /// <param name="message">The message object to be encoded or serialized</param>
+        /// <param name="messageKey">The message key</param>
+        /// <param name="messageValue">The message value</param>
         /// <param name="headers">The message headers</param>
         /// <returns></returns>
         Task<DeliveryResult<byte[], byte[]>> ProduceAsync(
-            string partitionKey,
-            object message,
+            object messageKey,
+            object messageValue,
             IMessageHeaders headers = null);
 
         /// <summary>
@@ -53,14 +53,14 @@ namespace KafkaFlow.Producers
         /// This should be used for high throughput scenarios: <see href="https://github.com/confluentinc/confluent-kafka-dotnet/wiki/Producer#produceasync-vs-produce"/>
         /// </summary>
         /// <param name="topic">The topic where the message wil be produced</param>
-        /// <param name="partitionKey">The message partition key, the value will be encoded suing UTF8</param>
-        /// <param name="message">The message object to be encoded or serialized</param>
+        /// <param name="messageKey">The message key</param>
+        /// <param name="messageValue">The message value</param>
         /// <param name="headers">The message headers</param>
         /// <param name="deliveryHandler">A handler with the operation result</param>
         void Produce(
             string topic,
-            string partitionKey,
-            object message,
+            object messageKey,
+            object messageValue,
             IMessageHeaders headers = null,
             Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null);
 
@@ -68,13 +68,13 @@ namespace KafkaFlow.Producers
         /// Produces a new message in the configured default topic
         /// This should be used for high throughput scenarios: <see href="https://github.com/confluentinc/confluent-kafka-dotnet/wiki/Producer#produceasync-vs-produce"/>
         /// </summary>
-        /// <param name="partitionKey">The message partition key, the value will be encoded suing UTF8</param>
-        /// <param name="message">The message object to be encoded or serialized</param>
+        /// <param name="messageKey">The message key</param>
+        /// <param name="messageValue">The message value</param>
         /// <param name="headers">The message headers</param>
         /// <param name="deliveryHandler">A handler with the operation result</param>
         void Produce(
-            string partitionKey,
-            object message,
+            object messageKey,
+            object messageValue,
             IMessageHeaders headers = null,
             Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null);
     }

--- a/src/KafkaFlow/Producers/MessageProducerWrapper.cs
+++ b/src/KafkaFlow/Producers/MessageProducerWrapper.cs
@@ -17,19 +17,19 @@ namespace KafkaFlow.Producers
 
         public Task<DeliveryResult<byte[], byte[]>> ProduceAsync(
             string topic,
-            string partitionKey,
+            object messageKey,
             object message,
             IMessageHeaders headers = null)
         {
             return this.producer.ProduceAsync(
                 topic,
-                partitionKey,
+                messageKey,
                 message,
                 headers);
         }
 
         public Task<DeliveryResult<byte[], byte[]>> ProduceAsync(
-            string partitionKey,
+            object partitionKey,
             object message,
             IMessageHeaders headers = null)
         {
@@ -41,7 +41,7 @@ namespace KafkaFlow.Producers
 
         public void Produce(
             string topic,
-            string partitionKey,
+            object partitionKey,
             object message,
             IMessageHeaders headers = null,
             Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null)
@@ -55,7 +55,7 @@ namespace KafkaFlow.Producers
         }
 
         public void Produce(
-            string partitionKey,
+            object partitionKey,
             object message,
             IMessageHeaders headers = null,
             Action<DeliveryReport<byte[], byte[]>> deliveryHandler = null)


### PR DESCRIPTION
# Description

The IMessageProducer was changed to allow the message key to be passed as an object and be encoded or serialized by the client application.

Fixes #153 

## How Has This Been Tested?

Unit and Integration tests were executed

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
