### PR TITLE
feat: expose partitions assigned and revoked events

### DIFF
--- a/src/KafkaFlow.UnitTests/Consumer/ConsumerManagerTests.cs
+++ b/src/KafkaFlow.UnitTests/Consumer/ConsumerManagerTests.cs
@@ -22,9 +22,10 @@ namespace KafkaFlow.UnitTests.Consumer
         private Mock<IConsumerWorkerPool> workerPoolMock;
         private Mock<IWorkerPoolFeeder> feederMock;
         private Mock<ILogHandler> logHandlerMock;
+        private readonly Mock<IDependencyResolver> dependencyResolver = new Mock<IDependencyResolver>();
 
-        private Action<IConsumer<byte[], byte[]>, List<TopicPartition>> onPartitionAssignedHandler;
-        private Action<IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> onPartitionRevokedHandler;
+        private Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> onPartitionAssignedHandler;
+        private Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> onPartitionRevokedHandler;
 
         [TestInitialize]
         public void Setup()
@@ -35,12 +36,12 @@ namespace KafkaFlow.UnitTests.Consumer
             this.logHandlerMock = new Mock<ILogHandler>(MockBehavior.Strict);
 
             this.consumerMock
-                .Setup(x => x.OnPartitionsAssigned(It.IsAny<Action<IConsumer<byte[], byte[]>, List<TopicPartition>>>()))
-                .Callback((Action<IConsumer<byte[], byte[]>, List<TopicPartition>> value) => this.onPartitionAssignedHandler = value);
+                .Setup(x => x.OnPartitionsAssigned(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>>>()))
+                .Callback((Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> value) => this.onPartitionAssignedHandler = value);
 
             this.consumerMock
-                .Setup(x => x.OnPartitionsRevoked(It.IsAny<Action<IConsumer<byte[], byte[]>, List<TopicPartitionOffset>>>()))
-                .Callback((Action<IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> value) => this.onPartitionRevokedHandler = value);
+                .Setup(x => x.OnPartitionsRevoked(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>>>()))
+                .Callback((Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> value) => this.onPartitionRevokedHandler = value);
 
             this.target = new ConsumerManager(
                 this.consumerMock.Object,
@@ -117,7 +118,7 @@ namespace KafkaFlow.UnitTests.Consumer
                 .Setup(x => x.Info(It.IsAny<string>(), It.IsAny<object>()));
 
             // Act
-            this.onPartitionAssignedHandler(consumer, partitions);
+            this.onPartitionAssignedHandler(this.dependencyResolver.Object, consumer, partitions);
 
             // Assert
             this.workerPoolMock.VerifyAll();
@@ -143,7 +144,7 @@ namespace KafkaFlow.UnitTests.Consumer
                 .Setup(x => x.Warning(It.IsAny<string>(), It.IsAny<object>()));
 
             // Act
-            this.onPartitionRevokedHandler(consumer, partitions);
+            this.onPartitionRevokedHandler(this.dependencyResolver.Object, consumer, partitions);
 
             // Assert
             this.workerPoolMock.VerifyAll();

--- a/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
@@ -20,6 +20,8 @@ namespace KafkaFlow.Configuration
             bool autoStoreOffsets,
             TimeSpan autoCommitInterval,
             IReadOnlyList<Action<string>> statisticsHandlers,
+            IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> partitionsAssignedHandlers,
+            IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> partitionsRevokedHandlers,
             ConsumerCustomFactory customFactory)
         {
             this.consumerConfig = consumerConfig ?? throw new ArgumentNullException(nameof(consumerConfig));
@@ -38,6 +40,8 @@ namespace KafkaFlow.Configuration
             this.ConsumerName = consumerName ?? Guid.NewGuid().ToString();
             this.WorkerCount = workerCount;
             this.StatisticsHandlers = statisticsHandlers;
+            this.PartitionsAssignedHandlers = partitionsAssignedHandlers;
+            this.PartitionsRevokedHandlers = partitionsRevokedHandlers;
             this.CustomFactory = customFactory;
 
             this.BufferSize = bufferSize > 0 ?
@@ -77,6 +81,10 @@ namespace KafkaFlow.Configuration
         public TimeSpan AutoCommitInterval { get; }
 
         public IReadOnlyList<Action<string>> StatisticsHandlers { get; }
+
+        public IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> PartitionsAssignedHandlers { get; }
+
+        public IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
 
         public ConsumerCustomFactory CustomFactory { get; }
 

--- a/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
@@ -11,6 +11,8 @@ namespace KafkaFlow.Configuration
     {
         private readonly List<string> topics = new();
         private readonly List<Action<string>> statisticsHandlers = new();
+        private readonly List<Action<IDependencyResolver, List<TopicPartition>>> partitionAssignedHandlers = new();
+        private readonly List<Action<IDependencyResolver, List<TopicPartitionOffset>>> partitionRevokedHandlers = new();
         private readonly ConsumerMiddlewareConfigurationBuilder middlewareConfigurationBuilder;
 
         private ConsumerConfig consumerConfig;
@@ -142,6 +144,18 @@ namespace KafkaFlow.Configuration
             return this;
         }
 
+        public IConsumerConfigurationBuilder WithPartitionsAssignedHandler(Action<IDependencyResolver, List<TopicPartition>> partitionsAssignedHandler)
+        {
+            this.partitionAssignedHandlers.Add(partitionsAssignedHandler);
+            return this;
+        }
+
+        public IConsumerConfigurationBuilder WithPartitionsRevokedHandler(Action<IDependencyResolver, List<TopicPartitionOffset>> partitionsRevokedHandler)
+        {
+            this.partitionRevokedHandlers.Add(partitionsRevokedHandler);
+            return this;
+        }
+
         public IConsumerConfigurationBuilder WithStatisticsHandler(Action<string> statisticsHandler)
         {
             this.statisticsHandlers.Add(statisticsHandler);
@@ -187,6 +201,8 @@ namespace KafkaFlow.Configuration
                 this.autoStoreOffsets,
                 this.autoCommitInterval,
                 this.statisticsHandlers,
+                this.partitionAssignedHandlers,
+                this.partitionRevokedHandlers,
                 this.customFactory);
         }
     }

--- a/src/KafkaFlow/Configuration/IConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/IConsumerConfiguration.cs
@@ -26,6 +26,10 @@ namespace KafkaFlow.Configuration
 
         IReadOnlyList<Action<string>> StatisticsHandlers { get; }
 
+        IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> PartitionsAssignedHandlers { get; }
+
+        IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
+
         ConsumerCustomFactory CustomFactory { get; }
 
         ConsumerConfig GetKafkaConfig();

--- a/src/KafkaFlow/Consumers/ConsumerManager.cs
+++ b/src/KafkaFlow/Consumers/ConsumerManager.cs
@@ -23,8 +23,8 @@
             this.WorkerPool = consumerWorkerPool;
             this.Feeder = feeder;
 
-            this.Consumer.OnPartitionsAssigned((_, partitions) => this.OnPartitionAssigned(partitions));
-            this.Consumer.OnPartitionsRevoked((_, partitions) => this.OnPartitionRevoked(partitions));
+            this.Consumer.OnPartitionsAssigned((resolver, _, partitions) => this.OnPartitionAssigned(partitions));
+            this.Consumer.OnPartitionsRevoked((resolver, _, partitions) => this.OnPartitionRevoked(partitions));
         }
 
         public IWorkerPoolFeeder Feeder { get; }

--- a/src/KafkaFlow/Consumers/IConsumer.cs
+++ b/src/KafkaFlow/Consumers/IConsumer.cs
@@ -9,9 +9,9 @@ namespace KafkaFlow.Consumers
 
     internal interface IConsumer : IDisposable
     {
-        void OnPartitionsAssigned(Action<IConsumer<byte[], byte[]>, List<TopicPartition>> handler);
+        void OnPartitionsAssigned(Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> handler);
 
-        void OnPartitionsRevoked(Action<IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> handler);
+        void OnPartitionsRevoked(Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> handler);
 
         void OnError(Action<IConsumer<byte[], byte[]>, Error> handler);
 

--- a/src/KafkaFlow/Extensions/ConfigurationBuilderExtensions.cs
+++ b/src/KafkaFlow/Extensions/ConfigurationBuilderExtensions.cs
@@ -1,5 +1,7 @@
 namespace KafkaFlow
 {
+    using System;
+    using System.Collections.Generic;
     using Confluent.Kafka;
     using KafkaFlow.Configuration;
 
@@ -50,6 +52,34 @@ namespace KafkaFlow
         public static IConsumerConfigurationBuilder WithConsumerConfig(this IConsumerConfigurationBuilder builder, ConsumerConfig config)
         {
             return ((ConsumerConfigurationBuilder) builder).WithConsumerConfig(config);
+        }
+
+        /// <summary>
+        /// Adds a handler for the Kafka consumer partitions assigned
+        /// </summary>
+        /// <param name="builder">The configuration builder</param>
+        /// <param name="partitionsAssignedHandler">A handler for the consumer partitions assigned</param>
+        /// <returns></returns>
+        public static IConsumerConfigurationBuilder WithPartitionsAssignedHandler(
+            this IConsumerConfigurationBuilder builder,
+            Action<IDependencyResolver, List<TopicPartition>> partitionsAssignedHandler)
+        {
+            ((ConsumerConfigurationBuilder)builder).WithPartitionsAssignedHandler(partitionsAssignedHandler);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a handler for the Kafka consumer partitions revoked
+        /// </summary>
+        /// <param name="builder">The configuration builder</param>
+        /// <param name="partitionsRevokedHandler">A handler for the consumer partitions revoked</param>
+        /// <returns></returns>
+        public static IConsumerConfigurationBuilder WithPartitionsRevokedHandler(
+            this IConsumerConfigurationBuilder builder,
+            Action<IDependencyResolver, List<TopicPartitionOffset>> partitionsRevokedHandler)
+        {
+            ((ConsumerConfigurationBuilder)builder).WithPartitionsRevokedHandler(partitionsRevokedHandler);
+            return builder;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Added configuration methods to allow clients to implement some tasks when Kafka events partitions assigned and revoked occur

Fixes #170

## How Has This Been Tested?

Was complemented the existents tests.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
