### PR TITLE
fix: fixes NewtonsoftJsonSerializer wrongly closing streams

### DIFF
--- a/src/KafkaFlow.Serializer.NewtonsoftJson/NewtonsoftJsonSerializer.cs
+++ b/src/KafkaFlow.Serializer.NewtonsoftJson/NewtonsoftJsonSerializer.cs
@@ -33,7 +33,7 @@
         /// <inheritdoc/>
         public Task SerializeAsync(object message, Stream output, ISerializerContext context)
         {
-            using var sw = new StreamWriter(output, Encoding.UTF8);
+            using var sw = new StreamWriter(output, Encoding.UTF8, -1, true);
             var serializer = JsonSerializer.CreateDefault(this.settings);
 
             serializer.Serialize(sw, message);
@@ -44,7 +44,13 @@
         /// <inheritdoc/>
         public Task<object> DeserializeAsync(Stream input, Type type, ISerializerContext context)
         {
-            using var sr = new StreamReader(input, Encoding.UTF8);
+            using var sr = new StreamReader(
+                input,
+                Encoding.UTF8,
+                true,
+                -1,
+                true);
+
             var serializer = JsonSerializer.CreateDefault(this.settings);
 
             return Task.FromResult(serializer.Deserialize(sr, type));


### PR DESCRIPTION
# Description

fixes NewtonsoftJsonSerializer wrongly closing streams

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
