### PR TITLE
feat: allow to execute async operations on partitions revoked and par…

### DIFF
--- a/samples/KafkaFlow.Sample/Program.cs
+++ b/samples/KafkaFlow.Sample/Program.cs
@@ -50,6 +50,11 @@
                                     .WithBufferSize(100)
                                     .WithWorkersCount(20)
                                     .WithAutoOffsetReset(AutoOffsetReset.Latest)
+                                    .WithPartitionsRevokedHandler(async (resolver, list) =>
+                                    {
+                                        await Task.Delay(1000);
+                                        Console.WriteLine($"Done some async operation with the lost partitions ({string.Join(',', list)})");
+                                    })
                                     .AddMiddlewares(
                                         middlewares => middlewares
                                             .AddSerializer<ProtobufNetSerializer>()
@@ -154,6 +159,7 @@
 
                     case "exit":
                         await bus.StopAsync();
+                        Console.WriteLine("Kafka bus stopped");
                         return;
                 }
             }

--- a/src/KafkaFlow.UnitTests/ConfigurationBuilders/ConsumerConfigurationBuilderTests.cs
+++ b/src/KafkaFlow.UnitTests/ConfigurationBuilders/ConsumerConfigurationBuilderTests.cs
@@ -2,6 +2,7 @@ namespace KafkaFlow.UnitTests.ConfigurationBuilders
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using AutoFixture;
     using Confluent.Kafka;
     using FluentAssertions;
@@ -85,8 +86,8 @@ namespace KafkaFlow.UnitTests.ConfigurationBuilders
             const int maxPollIntervalMs = 500000;
             ConsumerCustomFactory customFactory = (producer, _) => producer;
             Action<string> statisticsHandler = _ => { };
-            Action<IDependencyResolver, List<TopicPartition>> partitionsAssignedHandler = (_, _) => { };
-            Action<IDependencyResolver, List<TopicPartitionOffset>> partitionsRevokedHandler = (_, _) => { };
+            Func<IDependencyResolver, List<TopicPartition>, Task> partitionsAssignedHandler = (_, _) => Task.CompletedTask;
+            Func<IDependencyResolver, List<TopicPartitionOffset>, Task> partitionsRevokedHandler = (_, _) => Task.CompletedTask;
             const int statisticsIntervalMs = 100;
             var consumerConfig = new ConsumerConfig();
 

--- a/src/KafkaFlow.UnitTests/Consumer/ConsumerManagerTests.cs
+++ b/src/KafkaFlow.UnitTests/Consumer/ConsumerManagerTests.cs
@@ -15,6 +15,7 @@ namespace KafkaFlow.UnitTests.Consumer
     public class ConsumerManagerTests
     {
         private readonly Fixture fixture = new();
+        private readonly Mock<IDependencyResolver> dependencyResolver = new Mock<IDependencyResolver>();
 
         private ConsumerManager target;
 
@@ -22,10 +23,8 @@ namespace KafkaFlow.UnitTests.Consumer
         private Mock<IConsumerWorkerPool> workerPoolMock;
         private Mock<IWorkerPoolFeeder> feederMock;
         private Mock<ILogHandler> logHandlerMock;
-        private readonly Mock<IDependencyResolver> dependencyResolver = new Mock<IDependencyResolver>();
-
-        private Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> onPartitionAssignedHandler;
-        private Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> onPartitionRevokedHandler;
+        private Func<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>, Task> onPartitionAssignedHandler;
+        private Func<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>, Task> onPartitionRevokedHandler;
 
         [TestInitialize]
         public void Setup()
@@ -36,12 +35,12 @@ namespace KafkaFlow.UnitTests.Consumer
             this.logHandlerMock = new Mock<ILogHandler>(MockBehavior.Strict);
 
             this.consumerMock
-                .Setup(x => x.OnPartitionsAssigned(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>>>()))
-                .Callback((Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> value) => this.onPartitionAssignedHandler = value);
+                .Setup(x => x.OnPartitionsAssigned(It.IsAny<Func<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>, Task>>()))
+                .Callback((Func<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>, Task> value) => this.onPartitionAssignedHandler = value);
 
             this.consumerMock
-                .Setup(x => x.OnPartitionsRevoked(It.IsAny<Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>>>()))
-                .Callback((Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> value) => this.onPartitionRevokedHandler = value);
+                .Setup(x => x.OnPartitionsRevoked(It.IsAny<Func<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>, Task>>()))
+                .Callback((Func<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>, Task> value) => this.onPartitionRevokedHandler = value);
 
             this.target = new ConsumerManager(
                 this.consumerMock.Object,

--- a/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfiguration.cs
@@ -2,6 +2,7 @@ namespace KafkaFlow.Configuration
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Confluent.Kafka;
 
     internal class ConsumerConfiguration : IConsumerConfiguration
@@ -20,8 +21,8 @@ namespace KafkaFlow.Configuration
             bool autoStoreOffsets,
             TimeSpan autoCommitInterval,
             IReadOnlyList<Action<string>> statisticsHandlers,
-            IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> partitionsAssignedHandlers,
-            IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> partitionsRevokedHandlers,
+            IReadOnlyList<Func<IDependencyResolver, List<TopicPartition>, Task>> partitionsAssignedHandlers,
+            IReadOnlyList<Func<IDependencyResolver, List<TopicPartitionOffset>, Task>> partitionsRevokedHandlers,
             ConsumerCustomFactory customFactory)
         {
             this.consumerConfig = consumerConfig ?? throw new ArgumentNullException(nameof(consumerConfig));
@@ -82,9 +83,9 @@ namespace KafkaFlow.Configuration
 
         public IReadOnlyList<Action<string>> StatisticsHandlers { get; }
 
-        public IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> PartitionsAssignedHandlers { get; }
+        public IReadOnlyList<Func<IDependencyResolver, List<TopicPartition>, Task>> PartitionsAssignedHandlers { get; }
 
-        public IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
+        public IReadOnlyList<Func<IDependencyResolver, List<TopicPartitionOffset>, Task>> PartitionsRevokedHandlers { get; }
 
         public ConsumerCustomFactory CustomFactory { get; }
 

--- a/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
+++ b/src/KafkaFlow/Configuration/ConsumerConfigurationBuilder.cs
@@ -4,6 +4,7 @@ namespace KafkaFlow.Configuration
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Linq;
+    using System.Threading.Tasks;
     using Confluent.Kafka;
     using KafkaFlow.Consumers.DistributionStrategies;
 
@@ -11,8 +12,8 @@ namespace KafkaFlow.Configuration
     {
         private readonly List<string> topics = new();
         private readonly List<Action<string>> statisticsHandlers = new();
-        private readonly List<Action<IDependencyResolver, List<TopicPartition>>> partitionAssignedHandlers = new();
-        private readonly List<Action<IDependencyResolver, List<TopicPartitionOffset>>> partitionRevokedHandlers = new();
+        private readonly List<Func<IDependencyResolver, List<TopicPartition>, Task>> partitionAssignedHandlers = new();
+        private readonly List<Func<IDependencyResolver, List<TopicPartitionOffset>, Task>> partitionRevokedHandlers = new();
         private readonly ConsumerMiddlewareConfigurationBuilder middlewareConfigurationBuilder;
 
         private ConsumerConfig consumerConfig;
@@ -144,13 +145,13 @@ namespace KafkaFlow.Configuration
             return this;
         }
 
-        public IConsumerConfigurationBuilder WithPartitionsAssignedHandler(Action<IDependencyResolver, List<TopicPartition>> partitionsAssignedHandler)
+        public IConsumerConfigurationBuilder WithPartitionsAssignedHandler(Func<IDependencyResolver, List<TopicPartition>, Task> partitionsAssignedHandler)
         {
             this.partitionAssignedHandlers.Add(partitionsAssignedHandler);
             return this;
         }
 
-        public IConsumerConfigurationBuilder WithPartitionsRevokedHandler(Action<IDependencyResolver, List<TopicPartitionOffset>> partitionsRevokedHandler)
+        public IConsumerConfigurationBuilder WithPartitionsRevokedHandler(Func<IDependencyResolver, List<TopicPartitionOffset>, Task> partitionsRevokedHandler)
         {
             this.partitionRevokedHandlers.Add(partitionsRevokedHandler);
             return this;

--- a/src/KafkaFlow/Configuration/IConsumerConfiguration.cs
+++ b/src/KafkaFlow/Configuration/IConsumerConfiguration.cs
@@ -2,6 +2,7 @@ namespace KafkaFlow.Configuration
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Confluent.Kafka;
 
     /// <summary>
@@ -62,12 +63,12 @@ namespace KafkaFlow.Configuration
         /// <summary>
         /// Gets the handlers that will be called when the partitions are assigned
         /// </summary>
-        IReadOnlyList<Action<IDependencyResolver, List<TopicPartition>>> PartitionsAssignedHandlers { get; }
+        IReadOnlyList<Func<IDependencyResolver, List<TopicPartition>, Task>> PartitionsAssignedHandlers { get; }
 
         /// <summary>
         /// Gets the handlers that will be called when the partitions are revoked
         /// </summary>
-        IReadOnlyList<Action<IDependencyResolver, List<TopicPartitionOffset>>> PartitionsRevokedHandlers { get; }
+        IReadOnlyList<Func<IDependencyResolver, List<TopicPartitionOffset>, Task>> PartitionsRevokedHandlers { get; }
 
         /// <summary>
         /// Gets the custom factory used to create a new <see cref="KafkaFlow.Consumers.IConsumer"/>

--- a/src/KafkaFlow/Consumers/ConsumerManager.cs
+++ b/src/KafkaFlow/Consumers/ConsumerManager.cs
@@ -55,25 +55,22 @@
             this.Consumer.Dispose();
         }
 
-        private void OnPartitionRevoked(IEnumerable<TopicPartitionOffset> topicPartitions)
+        private Task OnPartitionRevoked(IEnumerable<TopicPartitionOffset> topicPartitions)
         {
             this.logHandler.Warning(
                 "Partitions revoked",
                 this.GetConsumerLogInfo(topicPartitions.Select(x => x.TopicPartition)));
 
-            this.WorkerPool.StopAsync().GetAwaiter().GetResult();
+            return this.WorkerPool.StopAsync();
         }
 
-        private void OnPartitionAssigned(IReadOnlyCollection<TopicPartition> partitions)
+        private Task OnPartitionAssigned(IReadOnlyCollection<TopicPartition> partitions)
         {
             this.logHandler.Info(
                 "Partitions assigned",
                 this.GetConsumerLogInfo(partitions));
 
-            this.WorkerPool
-                .StartAsync(partitions)
-                .GetAwaiter()
-                .GetResult();
+            return this.WorkerPool.StartAsync(partitions);
         }
 
         private object GetConsumerLogInfo(IEnumerable<TopicPartition> partitions) => new

--- a/src/KafkaFlow/Consumers/IConsumer.cs
+++ b/src/KafkaFlow/Consumers/IConsumer.cs
@@ -38,13 +38,13 @@ namespace KafkaFlow.Consumers
         /// Register a handler to be executed when the partitions are assigned
         /// </summary>
         /// <param name="handler">The handler that will be executed</param>
-        void OnPartitionsAssigned(Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>> handler);
+        void OnPartitionsAssigned(Func<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartition>, Task> handler);
 
         /// <summary>
         /// Register a handler to be executed when the partitions are revoked
         /// </summary>
         /// <param name="handler">The handler that will be executed</param>
-        void OnPartitionsRevoked(Action<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>> handler);
+        void OnPartitionsRevoked(Func<IDependencyResolver, IConsumer<byte[], byte[]>, List<TopicPartitionOffset>, Task> handler);
 
         /// <summary>
         /// Register a handler to be executed when an error occurs

--- a/src/KafkaFlow/Extensions/ConfigurationBuilderExtensions.cs
+++ b/src/KafkaFlow/Extensions/ConfigurationBuilderExtensions.cs
@@ -2,6 +2,7 @@ namespace KafkaFlow
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Confluent.Kafka;
     using KafkaFlow.Configuration;
 
@@ -62,7 +63,7 @@ namespace KafkaFlow
         /// <returns></returns>
         public static IConsumerConfigurationBuilder WithPartitionsAssignedHandler(
             this IConsumerConfigurationBuilder builder,
-            Action<IDependencyResolver, List<TopicPartition>> partitionsAssignedHandler)
+            Func<IDependencyResolver, List<TopicPartition>, Task> partitionsAssignedHandler)
         {
             ((ConsumerConfigurationBuilder)builder).WithPartitionsAssignedHandler(partitionsAssignedHandler);
             return builder;
@@ -76,7 +77,7 @@ namespace KafkaFlow
         /// <returns></returns>
         public static IConsumerConfigurationBuilder WithPartitionsRevokedHandler(
             this IConsumerConfigurationBuilder builder,
-            Action<IDependencyResolver, List<TopicPartitionOffset>> partitionsRevokedHandler)
+            Func<IDependencyResolver, List<TopicPartitionOffset>, Task> partitionsRevokedHandler)
         {
             ((ConsumerConfigurationBuilder)builder).WithPartitionsRevokedHandler(partitionsRevokedHandler);
             return builder;


### PR DESCRIPTION
# Description

Adapt `WithPartitionsRevokedHandler` and `WithPartitionsAssignedHandler` to execute async operations in a safe way.

Fixes #176 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
