### PR TITLE
fix: set KafkaFlow.Admin.WebApi as packable

### DIFF
--- a/src/KafkaFlow.Admin.WebApi/KafkaFlow.Admin.WebApi.csproj
+++ b/src/KafkaFlow.Admin.WebApi/KafkaFlow.Admin.WebApi.csproj
@@ -5,6 +5,7 @@
         <OutputType>Library</OutputType>
         <PackageId>KafkaFlow.Admin.WebApi</PackageId>
         <Description>Allows KafkaFlow to use the Admin Web API</Description>
+        <IsPackable>true</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
# Description

KafkaFlow.Admin.WebApi is not being published since version 1.5.6. 

This PR fixes it by setting the project KafkaFlow.Admin.WebApi as packable.

Fixes # (issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
