### PR TITLE
fix: avoid to loss partition key when compressing

### DIFF
--- a/src/KafkaFlow.Compressor/CompressorConsumerMiddleware.cs
+++ b/src/KafkaFlow.Compressor/CompressorConsumerMiddleware.cs
@@ -25,7 +25,7 @@
             if (!(context.Message.Value is byte[] rawData))
             {
                 throw new InvalidOperationException(
-                    $"{nameof(context.Message)} must be a byte array to be decompressed and it is '{context.Message.GetType().FullName}'");
+                    $"{nameof(context.Message.Value)} must be a byte array to be decompressed and it is '{context.Message.Value.GetType().FullName}'");
             }
 
             var data = this.compressor.Decompress(rawData);

--- a/src/KafkaFlow.Compressor/CompressorProducerMiddleware.cs
+++ b/src/KafkaFlow.Compressor/CompressorProducerMiddleware.cs
@@ -25,12 +25,12 @@
             if (context.Message.Value is not byte[] rawData)
             {
                 throw new InvalidOperationException(
-                    $"{nameof(context.Message)} must be a byte array to be compressed and it is '{context.Message.GetType().FullName}'");
+                    $"{nameof(context.Message.Value)} must be a byte array to be compressed and it is '{context.Message.Value.GetType().FullName}'");
             }
 
             var data = this.compressor.Compress(rawData);
 
-            return next(context.SetMessage(context.Message.Value, data));
+            return next(context.SetMessage(context.Message.Key, data));
         }
     }
 }


### PR DESCRIPTION
# Description

When compressing the message with any CompressorProducerMiddleware, the partition key is being overwritten with the message value.

This PR fixed this issue.

Fixes # (issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
