### PR TITLE
fix: fixes retro-compatibility on NewtonsoftJsonSerializer

### DIFF
--- a/src/KafkaFlow.Serializer.NewtonsoftJson/NewtonsoftJsonSerializer.cs
+++ b/src/KafkaFlow.Serializer.NewtonsoftJson/NewtonsoftJsonSerializer.cs
@@ -11,8 +11,9 @@
     /// </summary>
     public class NewtonsoftJsonSerializer : ISerializer
     {
-        private const int DefaulBufferSize = 1024;
+        private const int DefaultBufferSize = 1024;
 
+        private static readonly UTF8Encoding UTF8NoBom = new (false);
         private readonly JsonSerializerSettings settings;
 
         /// <summary>
@@ -35,7 +36,7 @@
         /// <inheritdoc/>
         public Task SerializeAsync(object message, Stream output, ISerializerContext context)
         {
-            using var sw = new StreamWriter(output, Encoding.UTF8, DefaulBufferSize, true);
+            using var sw = new StreamWriter(output, UTF8NoBom, DefaultBufferSize, true);
             var serializer = JsonSerializer.CreateDefault(this.settings);
 
             serializer.Serialize(sw, message);
@@ -48,9 +49,9 @@
         {
             using var sr = new StreamReader(
                 input,
-                Encoding.UTF8,
+                UTF8NoBom,
                 true,
-                DefaulBufferSize,
+                DefaultBufferSize,
                 true);
 
             var serializer = JsonSerializer.CreateDefault(this.settings);


### PR DESCRIPTION
# Description

NewtonsoftJsonSerializer is not working properly with versions previous than V2

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
