### PR TITLE
refactor: use action name as route name on webapi

### DIFF
--- a/src/KafkaFlow.Admin.WebApi/Controllers/ConsumersController.cs
+++ b/src/KafkaFlow.Admin.WebApi/Controllers/ConsumersController.cs
@@ -1,6 +1,5 @@
 namespace KafkaFlow.Admin.WebApi.Controllers
 {
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using KafkaFlow.Admin.Messages;
@@ -35,9 +34,9 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// </summary>
         /// <param name="groupId">Identifier of the group</param>
         /// <returns>A list of consumers</returns>
-        [HttpGet(Name="GetConsumersByGroupId")]
+        [HttpGet(Name=nameof(GetConsumersByGroupId))]
         [ProducesResponseType(typeof(ConsumersResponse), 200)]
-        public IActionResult Get([FromRoute] string groupId)
+        public IActionResult GetConsumersByGroupId([FromRoute] string groupId)
         {
             return this.Ok(
                 new ConsumersResponse
@@ -56,10 +55,10 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// <param name="consumerName">Name of consumer</param>
         /// <returns>A list of consumers</returns>
         [HttpGet]
-        [Route("{consumerName}", Name="GetConsumerByGroupIdName")]
+        [Route("{consumerName}", Name=nameof(GetConsumerByGroupIdName))]
         [ProducesResponseType(typeof(ConsumerResponse), 200)]
         [ProducesResponseType(404)]
-        public IActionResult Get(
+        public IActionResult GetConsumerByGroupIdName(
             [FromRoute] string groupId,
             [FromRoute] string consumerName)
         {
@@ -81,10 +80,10 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// <param name="consumerName">Name of consumer</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
         [HttpPost]
-        [Route("{consumerName}/pause", Name="PauseConsumer")]
+        [Route("{consumerName}/pause", Name=nameof(PauseConsumer))]
         [ProducesResponseType(202)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Pause(
+        public async Task<IActionResult> PauseConsumer(
             [FromRoute] string groupId,
             [FromRoute] string consumerName)
         {
@@ -112,10 +111,10 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// <param name="consumerName">Name of consumer</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
         [HttpPost]
-        [Route("{consumerName}/resume", Name="ResumeConsumer")]
+        [Route("{consumerName}/resume", Name=nameof(ResumeConsumer))]
         [ProducesResponseType(202)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Resume(
+        public async Task<IActionResult> ResumeConsumer(
             [FromRoute] string groupId,
             [FromRoute] string consumerName)
         {
@@ -143,10 +142,10 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// <param name="consumerName">Name of consumer</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
         [HttpPost]
-        [Route("{consumerName}/restart", Name="RestartConsumer")]
+        [Route("{consumerName}/restart", Name=nameof(RestartConsumer))]
         [ProducesResponseType(202)]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Restart(
+        public async Task<IActionResult> RestartConsumer(
             [FromRoute] string groupId,
             [FromRoute] string consumerName)
         {
@@ -175,7 +174,7 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// <param name="request">The request to confirm the operation</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
         [HttpPost]
-        [Route("{consumerName}/reset-offsets", Name="ResetOffsets")]
+        [Route("{consumerName}/reset-offsets", Name=nameof(ResetOffsets))]
         [ProducesResponseType(202)]
         [ProducesResponseType(404)]
         [ProducesResponseType(400)]
@@ -214,11 +213,11 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// <param name="request">The request to confirm the operation</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
         [HttpPost]
-        [Route("{consumerName}/rewind-offsets-to-date", Name="RewindOffsets")]
+        [Route("{consumerName}/rewind-offsets-to-date", Name=nameof(RewindOffsets))]
         [ProducesResponseType(202)]
         [ProducesResponseType(404)]
         [ProducesResponseType(400)]
-        public async Task<IActionResult> RewindOffsetsToDate(
+        public async Task<IActionResult> RewindOffsets(
             [FromRoute] string groupId,
             [FromRoute] string consumerName,
             [FromBody] RewindOffsetsToDateRequest request)
@@ -254,7 +253,7 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// <param name="request">The request to confirm the operation</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
         [HttpPost]
-        [Route("{consumerName}/change-worker-count", Name="ChangeWorkersCount")]
+        [Route("{consumerName}/change-worker-count", Name=nameof(ChangeWorkersCount))]
         [ProducesResponseType(202)]
         [ProducesResponseType(404)]
         [ProducesResponseType(400)]

--- a/src/KafkaFlow.Admin.WebApi/Controllers/GroupsController.cs
+++ b/src/KafkaFlow.Admin.WebApi/Controllers/GroupsController.cs
@@ -1,6 +1,5 @@
 namespace KafkaFlow.Admin.WebApi.Controllers
 {
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using KafkaFlow.Admin.Messages;
@@ -34,9 +33,9 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// Get all the consumer groups
         /// </summary>
         /// <returns>A list of consumer groups</returns>
-        [HttpGet(Name="GetAllGroups")]
+        [HttpGet(Name=nameof(GetAllGroups))]
         [ProducesResponseType(typeof(GroupsResponse), 200)]
-        public IActionResult Get()
+        public IActionResult GetAllGroups()
         {
             return this.Ok(
                 new GroupsResponse
@@ -58,9 +57,9 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// <param name="groupId">Identifier of the group</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
         [HttpPost]
-        [Route("{groupId}/pause", Name="PauseGroup")]
+        [Route("{groupId}/pause", Name=nameof(PauseGroup))]
         [ProducesResponseType(202)]
-        public async Task<IActionResult> Pause([FromRoute] string groupId)
+        public async Task<IActionResult> PauseGroup([FromRoute] string groupId)
         {
             await this.adminProducer.ProduceAsync(
                 new PauseConsumersByGroup
@@ -77,9 +76,9 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// <param name="groupId">Identifier of the group</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
         [HttpPost]
-        [Route("{groupId}/resume", Name="ResumeGroup")]
+        [Route("{groupId}/resume", Name=nameof(ResumeGroup))]
         [ProducesResponseType(202)]
-        public async Task<IActionResult> Resume([FromRoute] string groupId)
+        public async Task<IActionResult> ResumeGroup([FromRoute] string groupId)
         {
             await this.adminProducer.ProduceAsync(
                 new ResumeConsumersByGroup

--- a/src/KafkaFlow.Admin.WebApi/Controllers/TelemetryController.cs
+++ b/src/KafkaFlow.Admin.WebApi/Controllers/TelemetryController.cs
@@ -26,9 +26,9 @@ namespace KafkaFlow.Admin.WebApi.Controllers
         /// Get telemetry data from all the consumer groups
         /// </summary>
         /// <returns>A telemetry response</returns>
-        [HttpGet(Name="GetTelemetry")]
+        [HttpGet(Name=nameof(GetTelemetry))]
         [ProducesResponseType(typeof(TelemetryResponse), 200)]
-        public IActionResult Get()
+        public IActionResult GetTelemetry()
         {
             var metrics = this.storage.Get();
 


### PR DESCRIPTION
# Description

In order to avoid magic strings on web api routes, this PR uses action name as route name on web api endpoints


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
