### PR TITLE
Allow to define the dashboard path

### DIFF
--- a/src/KafkaFlow.Admin.Dashboard/ApplicationBuilderExtensions.cs
+++ b/src/KafkaFlow.Admin.Dashboard/ApplicationBuilderExtensions.cs
@@ -11,14 +11,25 @@ namespace KafkaFlow.Admin.Dashboard
     public static class ApplicationBuilderExtensions
     {
         /// <summary>
-        /// Enable the KafkaFlow dashboard
+        /// Enable the KafkaFlow dashboard. The path will be `/kafka-flow`
         /// </summary>
         /// <param name="app">Instance of <see cref="IApplicationBuilder"/></param>
         /// <returns></returns>
         public static IApplicationBuilder UseKafkaFlowDashboard(this IApplicationBuilder app)
         {
+            return app.UseKafkaFlowDashboard("/kafka-flow");
+        }
+
+        /// <summary>
+        /// Enable the KafkaFlow dashboard
+        /// </summary>
+        /// <param name="app">Instance of <see cref="IApplicationBuilder"/></param>
+        /// <param name="pathMatch">The request path to match.</param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseKafkaFlowDashboard(this IApplicationBuilder app, PathString pathMatch)
+        {
             app.Map(
-                "/kafka-flow",
+                pathMatch,
                 builder =>
                 {
                     var provider = new ManifestEmbeddedFileProvider(


### PR DESCRIPTION
# Description

Allow to define the dashboard path.

Until now, the dashboard path is always `/kafka-flow` and it
does not exist any method to change the configuration

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
