### PR TITLE
fix: requeue failed offsets

### DIFF
--- a/src/KafkaFlow.UnitTests/OffsetCommitterTests.cs
+++ b/src/KafkaFlow.UnitTests/OffsetCommitterTests.cs
@@ -1,0 +1,103 @@
+namespace KafkaFlow.UnitTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using Confluent.Kafka;
+    using KafkaFlow.Consumers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class OffsetCommitterTests
+    {
+        private const int TestTimeout = 1000;
+
+        private Mock<IConsumer> consumerMock;
+
+        private Mock<ILogHandler> logHandlerMock;
+
+        private TopicPartition topicPartition;
+
+        private OffsetCommitter offsetCommitter;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.consumerMock = new Mock<IConsumer>();
+            this.logHandlerMock = new Mock<ILogHandler>();
+            this.topicPartition = new TopicPartition("topic-A", new Partition(1));
+
+            this.consumerMock.Setup(c => c.Configuration.AutoCommitInterval)
+                .Returns(TimeSpan.FromMilliseconds(10));
+
+            this.offsetCommitter = new OffsetCommitter(this.consumerMock.Object, this.logHandlerMock.Object);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            this.offsetCommitter.Dispose();
+        }
+
+        [TestMethod]
+        public void StoreOffset_ShouldCommit()
+        {
+            // Arrange
+            var offset = new TopicPartitionOffset(this.topicPartition, new Offset(1));
+            var expectedOffsets = new[] { offset };
+
+            var ready = new ManualResetEvent(false);
+
+            this.consumerMock
+                .Setup(c => c.Commit(It.Is<IEnumerable<TopicPartitionOffset>>(l => l.SequenceEqual(expectedOffsets))))
+                .Callback((IEnumerable<TopicPartitionOffset> _) =>
+                {
+                    ready.Set();
+                });
+
+            // Act
+            this.offsetCommitter.StoreOffset(offset);
+            ready.WaitOne(TestTimeout);
+
+            // Assert
+            this.consumerMock.Verify(
+                c => c.Commit(It.Is<IEnumerable<TopicPartitionOffset>>(l => l.SequenceEqual(expectedOffsets))),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public void StoreOffset_WithFailure_ShouldRequeueFailedOffsetAndCommit()
+        {
+            // Arrange
+            var offset = new TopicPartitionOffset(this.topicPartition, new Offset(2));
+            var expectedOffsets = new[] { offset };
+
+            var ready = new ManualResetEvent(false);
+            var hasThrown = false;
+
+            this.consumerMock
+                .Setup(c => c.Commit(It.Is<IEnumerable<TopicPartitionOffset>>(l => l.SequenceEqual(expectedOffsets))))
+                .Callback((IEnumerable<TopicPartitionOffset> _) =>
+                {
+                    if (!hasThrown)
+                    {
+                        hasThrown = true;
+                        throw new InvalidOperationException();
+                    }
+
+                    ready.Set();
+                });
+
+            // Act
+            this.offsetCommitter.StoreOffset(offset);
+            ready.WaitOne(TestTimeout);
+
+            // Assert
+            this.consumerMock.Verify(
+                c => c.Commit(It.Is<IEnumerable<TopicPartitionOffset>>(l => l.SequenceEqual(expectedOffsets))),
+                Times.Exactly(2));
+        }
+    }
+}

--- a/src/KafkaFlow/Consumers/OffsetCommitter.cs
+++ b/src/KafkaFlow/Consumers/OffsetCommitter.cs
@@ -2,6 +2,7 @@ namespace KafkaFlow.Consumers
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using Confluent.Kafka;
@@ -59,10 +60,19 @@ namespace KafkaFlow.Consumers
             }
             catch (Exception e)
             {
-                this.logHandler.Error(
+                this.logHandler.Warning(
                     "Error Commiting Offsets",
-                    e,
-                    null);
+                    new { ErrorMessage = e.Message });
+
+                this.RequeueFailedOffsets(offsets.Values);
+            }
+        }
+
+        private void RequeueFailedOffsets(IEnumerable<TopicPartitionOffset> offsets)
+        {
+            foreach (var tpo in offsets)
+            {
+                this.offsetsToCommit.TryAdd((tpo.Topic, tpo.Partition.Value), tpo);
             }
         }
     }


### PR DESCRIPTION
# Description

This PR fixes an issue where the framework would not retry committing offsets after a failure.

Fixes #213 

## How Has This Been Tested?

Added unit tests.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
