### PR TITLE
fix: fix schema subject names for Topic and TopicRecord strategies

### DIFF
--- a/src/KafkaFlow.Abstractions/ISerializerContext.cs
+++ b/src/KafkaFlow.Abstractions/ISerializerContext.cs
@@ -5,5 +5,9 @@ namespace KafkaFlow
     /// </summary>
     public interface ISerializerContext
     {
+        /// <summary>
+        /// Gets the topic associated with the message
+        /// </summary>
+        string Topic { get; }
     }
 }

--- a/src/KafkaFlow.Abstractions/SerializerContext.cs
+++ b/src/KafkaFlow.Abstractions/SerializerContext.cs
@@ -8,8 +8,22 @@ namespace KafkaFlow
         /// </summary>
         public static readonly ISerializerContext Empty = new SerializerContext();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SerializerContext"/> class.
+        /// </summary>
+        /// <param name="topic"><inheritdoc cref="Topic"/></param>
+        public SerializerContext(string topic)
+        {
+            this.Topic = topic;
+        }
+
         private SerializerContext()
         {
         }
+
+        /// <summary>
+        /// Gets the topic associated with the message
+        /// </summary>
+        public string Topic { get; }
     }
 }

--- a/src/KafkaFlow.SchemaRegistry/ConfluentDeserializerWrapper.cs
+++ b/src/KafkaFlow.SchemaRegistry/ConfluentDeserializerWrapper.cs
@@ -37,8 +37,9 @@ namespace KafkaFlow
         /// Deserialize a message using the passed deserializer
         /// </summary>
         /// <param name="input">The message stream to deserialize</param>
+        /// <param name="context">Additional information provided for deserialization</param>
         /// <returns></returns>
-        public abstract Task<object> DeserializeAsync(Stream input);
+        public abstract Task<object> DeserializeAsync(Stream input, ISerializerContext context);
 
         private class InnerConfluentDeserializerWrapper<T> : ConfluentDeserializerWrapper
         {
@@ -49,7 +50,7 @@ namespace KafkaFlow
                 this.deserializer = (IAsyncDeserializer<T>) deserializerFactory();
             }
 
-            public override async Task<object> DeserializeAsync(Stream input)
+            public override async Task<object> DeserializeAsync(Stream input, ISerializerContext context)
             {
                 using var buffer = MemoryStreamManager.GetStream();
 
@@ -59,7 +60,7 @@ namespace KafkaFlow
                     .DeserializeAsync(
                         new ReadOnlyMemory<byte>(buffer.GetBuffer(), 0, (int) buffer.Length),
                         false,
-                        Confluent.Kafka.SerializationContext.Empty)
+                        new SerializationContext(MessageComponentType.Value, context.Topic))
                     .ConfigureAwait(false);
             }
         }

--- a/src/KafkaFlow.SchemaRegistry/ConfluentSerializerWrapper.cs
+++ b/src/KafkaFlow.SchemaRegistry/ConfluentSerializerWrapper.cs
@@ -35,8 +35,9 @@ namespace KafkaFlow
         /// </summary>
         /// <param name="message">The message to serialize</param>
         /// <param name="output">Where the serialization result will be stored</param>
+        /// <param name="context">Additional information provided for serialization</param>
         /// <returns></returns>
-        public abstract Task SerializeAsync(object message, Stream output);
+        public abstract Task SerializeAsync(object message, Stream output, ISerializerContext context);
 
         private class InnerConfluentSerializerWrapper<T> : ConfluentSerializerWrapper
         {
@@ -47,10 +48,10 @@ namespace KafkaFlow
                 this.serializer = (IAsyncSerializer<T>) serializerFactory();
             }
 
-            public override async Task SerializeAsync(object message, Stream output)
+            public override async Task SerializeAsync(object message, Stream output, ISerializerContext context)
             {
                 var data = await this.serializer
-                    .SerializeAsync((T) message, Confluent.Kafka.SerializationContext.Empty)
+                    .SerializeAsync((T) message, new SerializationContext(MessageComponentType.Value, context.Topic))
                     .ConfigureAwait(false);
 
                 await output

--- a/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentAvro/ConfluentAvroSerializer.cs
+++ b/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentAvro/ConfluentAvroSerializer.cs
@@ -50,7 +50,7 @@
                         typeof(AvroSerializer<>).MakeGenericType(message.GetType()),
                         this.schemaRegistryClient,
                         this.serializerConfig))
-                .SerializeAsync(message, output);
+                .SerializeAsync(message, output, context);
         }
 
         /// <inheritdoc/>
@@ -64,7 +64,7 @@
                             typeof(AvroDeserializer<>).MakeGenericType(type),
                             this.schemaRegistryClient,
                             new AvroDeserializerConfig()))
-                .DeserializeAsync(input);
+                .DeserializeAsync(input, context);
         }
     }
 }

--- a/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentJson/ConfluentJsonSerializer.cs
+++ b/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentJson/ConfluentJsonSerializer.cs
@@ -68,7 +68,7 @@
                         this.schemaRegistryClient,
                         this.serializerConfig,
                         this.schemaGeneratorSettings))
-                .SerializeAsync(message, output);
+                .SerializeAsync(message, output, context);
         }
 
         /// <inheritdoc/>
@@ -82,7 +82,7 @@
                             typeof(JsonDeserializer<>).MakeGenericType(type),
                             Enumerable.Empty<KeyValuePair<string, string>>(),
                             null))
-                .DeserializeAsync(input);
+                .DeserializeAsync(input, context);
         }
     }
 }

--- a/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf/ConfluentProtobufSerializer.cs
+++ b/src/KafkaFlow.Serializer.SchemaRegistry.ConfluentProtobuf/ConfluentProtobufSerializer.cs
@@ -50,7 +50,7 @@
                         typeof(ProtobufSerializer<>).MakeGenericType(message.GetType()),
                         this.schemaRegistryClient,
                         this.serializerConfig))
-                .SerializeAsync(message, output);
+                .SerializeAsync(message, output, context);
         }
 
         /// <inheritdoc/>
@@ -63,7 +63,7 @@
                         .CreateInstance(
                             typeof(ProtobufDeserializer<>).MakeGenericType(type),
                             Enumerable.Empty<KeyValuePair<string, string>>()))
-                .DeserializeAsync(input);
+                .DeserializeAsync(input, context);
         }
     }
 }

--- a/src/KafkaFlow.Serializer/SerializerConsumerMiddleware.cs
+++ b/src/KafkaFlow.Serializer/SerializerConsumerMiddleware.cs
@@ -59,7 +59,7 @@
                 .DeserializeAsync(
                     stream,
                     messageType,
-                    SerializerContext.Empty)
+                    new SerializerContext(context.ConsumerContext.Topic))
                 .ConfigureAwait(false);
 
             await next(context.SetMessage(context.Message.Key, data)).ConfigureAwait(false);

--- a/src/KafkaFlow.Serializer/SerializerProducerMiddleware.cs
+++ b/src/KafkaFlow.Serializer/SerializerProducerMiddleware.cs
@@ -44,7 +44,7 @@
                     .SerializeAsync(
                         context.Message.Value,
                         buffer,
-                        SerializerContext.Empty)
+                        new SerializerContext(context.ProducerContext.Topic))
                     .ConfigureAwait(false);
 
                 messageValue = buffer.ToArray();

--- a/src/KafkaFlow.UnitTests/Serializers/SerializerConsumerMiddlewareTests.cs
+++ b/src/KafkaFlow.UnitTests/Serializers/SerializerConsumerMiddlewareTests.cs
@@ -112,6 +112,9 @@ namespace KafkaFlow.UnitTests.Serializers
             var rawMessage = new Message(rawKey, rawValue);
             var deserializedMessage = new TestMessage();
 
+            var consumerContext = new Mock<IConsumerContext>();
+            consumerContext.SetupGet(x => x.Topic).Returns("test-topic");
+
             var transformedContextMock = new Mock<IMessageContext>();
             IMessageContext resultContext = null;
 
@@ -130,6 +133,10 @@ namespace KafkaFlow.UnitTests.Serializers
             this.serializerMock
                 .Setup(x => x.DeserializeAsync(It.IsAny<Stream>(), messageType, It.IsAny<ISerializerContext>()))
                 .ReturnsAsync(deserializedMessage);
+
+            this.contextMock
+                .SetupGet(x => x.ConsumerContext)
+                .Returns(consumerContext.Object);
 
             // Act
             await this.target.Invoke(

--- a/src/KafkaFlow.UnitTests/Serializers/SerializerProducerMiddlewareTests.cs
+++ b/src/KafkaFlow.UnitTests/Serializers/SerializerProducerMiddlewareTests.cs
@@ -1,6 +1,5 @@
 namespace KafkaFlow.UnitTests.Serializers
 {
-    using System;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
@@ -40,6 +39,8 @@ namespace KafkaFlow.UnitTests.Serializers
             var key = new object();
             var deserializedMessage = new Message(key, new TestMessage());
             IMessageContext resultContext = null;
+            var producerContext = new Mock<IProducerContext>();
+            producerContext.SetupGet(x=>x.Topic).Returns("test-topic");
 
             var transformedContextMock = new Mock<IMessageContext>();
 
@@ -60,6 +61,10 @@ namespace KafkaFlow.UnitTests.Serializers
             this.contextMock
                 .Setup(x => x.SetMessage(key, It.Is<byte[]>(value => value.SequenceEqual(rawMessage))))
                 .Returns(transformedContextMock.Object);
+
+            this.contextMock
+                .SetupGet(x => x.ProducerContext)
+                .Returns(producerContext.Object);
 
             // Act
             await this.target.Invoke(


### PR DESCRIPTION
# Description

Added topic property to ISerializerContext to make topic available to ConfluentSerializerWrapper and ConfluentDeserializerWrapper.  This allows for the topic name to be used to build the subject name for a schema when using the Topic or TopicRecord subject name strategies.

Fixes #216 

## How Has This Been Tested?

I ran the KafkaFlow.Sample.Avro project with the topic, record, and topicrecord subject naming strategies.  I verified that in each case, 
 - messages were produced and consumed properly
 - schemas were added to the schema registry under the expected subject names.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
