### PR TITLE
fix: use just a single instance of ISchemaRegistryClient

### DIFF
--- a/src/KafkaFlow.SchemaRegistry/ClusterConfigurationBuilderExtensions.cs
+++ b/src/KafkaFlow.SchemaRegistry/ClusterConfigurationBuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace KafkaFlow
         {
             var config = new SchemaRegistryConfig();
             handler(config);
-            cluster.DependencyConfigurator.AddTransient<ISchemaRegistryClient>(_ => new CachedSchemaRegistryClient(config));
+            cluster.DependencyConfigurator.AddSingleton<ISchemaRegistryClient>(_ => new CachedSchemaRegistryClient(config));
             return cluster;
         }
     }


### PR DESCRIPTION
# Description

In order to avoid the ISchemaRegistryClient being disposed, now it is using lifetime = singleton when injecting this dependency

Fixes #230 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
