### PR TITLE
fix(producer): use default value for compression level

### DIFF
--- a/src/KafkaFlow.UnitTests/ConfigurationBuilders/ProducerConfigurationBuilderTests.cs
+++ b/src/KafkaFlow.UnitTests/ConfigurationBuilders/ProducerConfigurationBuilderTests.cs
@@ -98,5 +98,26 @@ namespace KafkaFlow.UnitTests.ConfigurationBuilders
             configuration.BaseProducerConfig.Should().BeSameAs(producerConfig);
             configuration.MiddlewaresConfigurations.Should().HaveCount(1);
         }
+
+        [TestMethod]
+        public void Build_UseCompressionWithoutCompressionLevel_ReturnDefaultValues()
+        {
+            // Arrange
+            var clusterConfiguration = this.fixture.Create<ClusterConfiguration>();
+
+            var compressionType = CompressionType.Gzip;
+
+            this.target
+                .WithCompression(compressionType);
+
+            // Act
+            var configuration = this.target.Build(clusterConfiguration);
+
+            // Assert
+            configuration.Cluster.Should().Be(clusterConfiguration);
+            configuration.Name.Should().Be(this.name);
+            configuration.BaseProducerConfig.CompressionType.Should().Be(compressionType);
+            configuration.BaseProducerConfig.CompressionLevel.Should().Be(-1);
+        }
     }
 }

--- a/src/KafkaFlow/Extensions/ConfigurationBuilderExtensions.cs
+++ b/src/KafkaFlow/Extensions/ConfigurationBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace KafkaFlow
         public static IProducerConfigurationBuilder WithCompression(
             this IProducerConfigurationBuilder builder,
             CompressionType compressionType,
-            int? compressionLevel = null)
+            int? compressionLevel = -1)
         {
             return ((ProducerConfigurationBuilder) builder).WithCompression(compressionType, compressionLevel);
         }


### PR DESCRIPTION
# Description

We almost have had a problem with the storage of Kafka disks and when we were investigating the root cause, we found the configuration `compression.level` does not use the default value of producer configuration of confluent.

## How Has This Been Tested?

This has been tested in the development environment and unit tests.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have added tests to cover my changes
-   [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
