### PR TITLE
fix: solve Offset Manager and Worker racing condition when stopping

### DIFF
--- a/src/KafkaFlow/Consumers/ConsumerWorker.cs
+++ b/src/KafkaFlow/Consumers/ConsumerWorker.cs
@@ -59,11 +59,9 @@ namespace KafkaFlow.Consumers
 
         public IEvent<IMessageContext> WorkerProcessingEnded => _workerProcessingEnded;
 
-        public ValueTask EnqueueAsync(
-            IMessageContext context,
-            CancellationToken stopCancellationToken)
+        public ValueTask EnqueueAsync(IMessageContext context)
         {
-            return _messagesBuffer.Writer.WriteAsync(context, stopCancellationToken);
+            return _messagesBuffer.Writer.WriteAsync(context, CancellationToken.None);
         }
 
         public Task StartAsync()

--- a/src/KafkaFlow/Consumers/ConsumerWorkerPool.cs
+++ b/src/KafkaFlow/Consumers/ConsumerWorkerPool.cs
@@ -127,7 +127,7 @@ namespace KafkaFlow.Consumers
 
         public async Task EnqueueAsync(ConsumeResult<byte[], byte[]> message, CancellationToken stopCancellationToken)
         {
-            await _startedTaskSource.Task.ConfigureAwait(false);
+            await _startedTaskSource.Task;
 
             var worker = (IConsumerWorker)await _distributionStrategy
                 .GetWorkerAsync(
@@ -136,8 +136,7 @@ namespace KafkaFlow.Consumers
                         message.Topic,
                         message.Partition.Value,
                         message.Message.Key,
-                        stopCancellationToken))
-                .ConfigureAwait(false);
+                        stopCancellationToken));
 
             if (worker is null)
             {
@@ -146,11 +145,9 @@ namespace KafkaFlow.Consumers
 
             var context = this.CreateMessageContext(message, worker);
 
-            await worker
-                .EnqueueAsync(context, stopCancellationToken)
-                .ConfigureAwait(false);
-
             _offsetManager.Enqueue(context.ConsumerContext);
+
+            await worker.EnqueueAsync(context);
         }
 
         private MessageContext CreateMessageContext(ConsumeResult<byte[], byte[]> message, IConsumerWorker worker)

--- a/src/KafkaFlow/Consumers/IConsumerWorker.cs
+++ b/src/KafkaFlow/Consumers/IConsumerWorker.cs
@@ -10,7 +10,7 @@ namespace KafkaFlow.Consumers
 
         IDependencyResolver WorkerDependencyResolver { get; }
 
-        ValueTask EnqueueAsync(IMessageContext context, CancellationToken stopCancellationToken);
+        ValueTask EnqueueAsync(IMessageContext context);
 
         Task StartAsync();
 


### PR DESCRIPTION
# Description

There was a racing condition between the Offset Manager and the Consumer Worker, which needed to be fixed. The Cancellation token that was passed to the EnqueueAsync worker method was removed, which meant that the worker would accept the message before stopping. Previously, the behaviour was to cancel the last message delivery, but to do this, we needed to try to enqueue the message in the worker and then enqueue the message in the Offset Manager. Calling the method in this order caused a racing condition, as the worker could process the message before it was enqueued in the Offset Manager, triggering an exception and stopping the consumer.

Fixes #482 #488

## How Has This Been Tested?

The tests were manually executed and the automated tests were run.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
