### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Run issue-metrics tool for items opened last month
       id: opened-metrics
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:farfetch/kafkaflow created:${{ env.last_month }} -reason:"not planned"'
@@ -51,7 +51,7 @@ jobs:
 
     - name: Run issue-metrics tool for items closed last month
       id: closed-metrics
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:farfetch/kafkaflow closed:${{ env.last_month }} -reason:"not planned"'
@@ -64,7 +64,7 @@ jobs:
 
     - name: Run issue-metrics tool for discussions opened last month
       id: opened-discussions-metrics
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:farfetch/kafkaflow type:discussions created:${{ env.last_month }} -reason:"not planned"'
@@ -77,7 +77,7 @@ jobs:
 
     - name: Run issue-metrics tool for discussions closed last month
       id: closed-discussions-metrics
-      uses: github/issue-metrics@v2
+      uses: github-community-projects/issue-metrics@v2
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:farfetch/kafkaflow type:discussions closed:${{ env.last_month }} -reason:"not planned"'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
